### PR TITLE
Add configuration options for spiflash

### DIFF
--- a/cw/cw305/capture.yaml
+++ b/cw/cw305/capture.yaml
@@ -3,6 +3,12 @@ device:
   fw_bin: objs/aes_serial_fpga_nexysvideo.bin
   pll_frequency: 25000000
   baudrate: 57600
+spiflash:
+  bin: bin/linux/spiflash
+  # FTDI USB id (vendor:product) ID and serial number can be extracted using the
+  # lsusb command.
+  dev_id: 0403:6014
+  dev_sn: FT2U2SK1
 capture:
   # Only AES-128 ECB is supported at this moment.
   key_len_bytes: 16

--- a/cw/cw305/capture_traces.py
+++ b/cw/cw305/capture_traces.py
@@ -14,13 +14,20 @@ import chipwhisperer as cw
 
 from util import device
 from util import plot
+from util import spiflash
 
 
-def initialize_test(device_cfg):
-  """Initialize test setup."""
+def initialize_capture(device_cfg, spiflash_cfg):
+  """Initialize capture."""
+  fw_programmer = spiflash.FtdiProgrammer(
+    spiflash_cfg['bin'],
+    spiflash_cfg['dev_id'],
+    spiflash_cfg['dev_sn'],
+    device_cfg['fw_bin'])
+
   ot = device.OpenTitan(
+    fw_programmer,
     device_cfg['fpga_bitstream'],
-    device_cfg['fw_bin'],
     device_cfg['pll_frequency'],
     device_cfg['baudrate'])
   print(f'Scope setup with sampling rate {ot.scope.clock.adc_rate} S/s')
@@ -83,5 +90,5 @@ def run_capture(capture_cfg, ot):
 if __name__ == "__main__":
   with open('capture.yaml') as f:
     cfg_file = yaml.load(f, Loader=yaml.FullLoader)
-  ot = initialize_test(cfg_file['device'])
+  ot = initialize_capture(cfg_file['device'], cfg_file['spiflash'])
   run_capture(cfg_file['capture'], ot)

--- a/cw/cw305/util/device.py
+++ b/cw/cw305/util/device.py
@@ -14,10 +14,10 @@ SPIFLASH=r'bin/linux/spiflash'
 
 
 class OpenTitan(object):
-  def __init__(self, bitstream, fw_image, pll_frequency, baudrate):
+  def __init__(self, fw_programmer, bitstream, pll_frequency, baudrate):
       self.fpga = self.initialize_fpga(bitstream, pll_frequency)
       self.scope = self.initialize_scope()
-      self.target = self.initialize_target(self.scope, fw_image, baudrate)
+      self.target = self.initialize_target(self.scope, fw_programmer, baudrate)
 
   def initialize_fpga(self, bitstream, pll_frequency):
     """Initializes FPGA bitstream and sets PLL frequency."""
@@ -58,16 +58,9 @@ class OpenTitan(object):
     assert (scope.clock.adc_locked), "ADC failed to lock"
     return scope
 
-  def load_fw(self, fw_image):
-    """Loads firmware image."""
-    # TODO: Make settings configurable.
-    command = [SPIFLASH, '--dev-id=0403:6014', '--dev-sn=FT2U2SK1',
-           '--input=' + fw_image]
-    subprocess.check_call(command)
-
-  def initialize_target(self, scope, fw_image, baudrate):
+  def initialize_target(self, scope, fw_programmer, baudrate):
     """Loads firmware image and initializes test target."""
-    self.load_fw(fw_image)
+    fw_programmer.run()
     time.sleep(0.5)
     target = cw.target(scope)
     target.output_len = 16

--- a/cw/cw305/util/spiflash.py
+++ b/cw/cw305/util/spiflash.py
@@ -1,0 +1,28 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Utilities used to download firmware images into the OpenTitan system."""
+
+import subprocess
+
+class FtdiProgrammer(object):
+  """Spiflash executable wrapper.
+
+  See doc/getting_started.md for details on how to connect the FTDI cable to
+  the CW305 FPGA target board.
+  """
+  def __init__(self, spiflash_path, dev_id, dev_sn, input):
+    """Initializes spiflash FTDI programmer.
+
+    Args:
+      spiflash_path: Path to spiflash executable.
+      dev_id: FTDI USB device ID in vendor:product hex format.
+      dev_sn: FTDI USB serial number as reported by lsusb.
+      input: Path to OpenTitan firmware image.
+    """
+    self.cmd = [spiflash_path, f'--dev-id={dev_id}', f'--dev-sn={dev_sn}',
+                f'--input={input}']
+
+  def run(self):
+    """Run spiflash utility with predefined command line arguments."""
+    subprocess.check_call(self.cmd)

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -7,6 +7,26 @@ In the meantime, check the following PRs:
 * https://github.com/lowRISC/opentitan/pull/2587
 * https://github.com/lowRISC/opentitan/pull/2735
 
+### Downloading code via FTDI
+
+Currently the target firmware is downloaded via a SPI FTDI interface using the
+[spiflash](https://docs.opentitan.org/sw/host/spiflash/README/) utility.
+A debian-compatible pre-built binary is available at
+`cw/cw305/bin/linux/spiflash`. See the following table for details on how to
+connect the FTDI interface to the CW305 FPGA target board.
+
+| FTDI Signal | CW305 FPGA | OpenTitan IO        |
+| ----------- | ---------- | ------------------- |
+| TCK         | JP3.A14    | TCK (IO_DPS0)       |
+| TDI         | JP3.A13    | TDI (IO_DPS1)       |
+| TDO         | JP3.A15    | TDO (IO_DPS2)       |
+| TMS         | JP3.B15    | TMS (IO_DPS3)       |
+| GPIOL0      | JP3.C12    | nTRST (IO_DPS4)     |
+| GPIOL1      | JP3.C11    | nSRST (IO_DPS5)     |
+| GPIOL2      | JP3.B14    | JTAG_SEL (IO_DPS6)  |
+| GPIOL3      | JP3.C14    | BOOTSTRAP (IO_DPS7) |
+| GND         | GND        | -                   |
+
 ## Running capture and attack
 
 Sample capture run:
@@ -40,7 +60,7 @@ Saving sample trace image to: doc/sample_traces.html
 Sample analysis run (Failed):
 
 ```console
-$ python3 cpa_attack.py 
+$ python3 cpa_attack.py
 Performing Attack: 100%|████████████████████| 5000/5000 [03:41<00:00, 22.77it/s]
 known_key: b'2b7e151628aed2a6abf7158809cf4f3c'
 key guess: b'97f0e4c3bc14ff64effa5fce0697d9e0'


### PR DESCRIPTION
* Make spiflash configuratble from capture.yaml.
* Add FTDI connectivity instructions to the doc/getting_started.md
  guide.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>