### PR TITLE
Fix python requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ __pypackages__/
 
 # ChipWhisperer project files
 projects/
+
+# Python requirements source directory
+src/

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -1,5 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Keep sorted.
+bokeh
 pyyaml
-chipwhisperer
 scared
 tqdm
-bokeh
+
+# The development version of the ChipWhisperer toolchain with latest features
+# and bug fixes needs to be installed in editable mode.
+-e git+https://github.com/newaetech/chipwhisperer.git#egg=chipwhisperer


### PR DESCRIPTION
This PR fixes the Python requirements to use upstream ChipWhisperer toolchain from GitHub as required for #8.

I will have to rebase this one, once #8 has been merged.