### PR TITLE
Rework simple capture

### DIFF
--- a/cw/cw305/simple_capture_traces.py
+++ b/cw/cw305/simple_capture_traces.py
@@ -108,6 +108,10 @@ def parse_args():
                       '-p',
                       type=int,
                       help="Plot number of traces.")
+  parser.add_argument('--start-delay',
+                      '-d',
+                      type=int,
+                      help="Number of seconds to wait between initialization and capture.")
   args = parser.parse_args()
   return args
 
@@ -126,6 +130,10 @@ if __name__ == "__main__":
     cfg_file['plot_capture']['num_traces'] = args.plot_traces
 
   ot = initialize_capture(cfg_file['device'], cfg_file['spiflash'])
+
+  if args.start_delay:
+    print(f'To reduce capture noise, you can now unplug the FTDI cable.')
+    time.sleep(args.start_delay)
 
   # Key and plaintext generator
   ktp = cw.ktp.Basic()

--- a/cw/cw305/util/device.py
+++ b/cw/cw305/util/device.py
@@ -42,7 +42,7 @@ class OpenTitan(object):
   def initialize_scope(self):
     """Initializes chipwhisperer scope."""
     scope = cw.scope()
-    scope.gain.db = 30
+    scope.gain.db = 27.5
     # Samples per trace - We oversample by 10x and AES is doing ~12/16 cycles per encryption.
     scope.adc.samples = 180
     scope.adc.offset = 0


### PR DESCRIPTION
This PR slightly reworks how the simple capture scripts handles failures (now retries in case of failures and prints a warning, previously it just silently skipped failed captures). Also, a configurable delay is added before the capture start in order to unplug the FTDI cable to reduce noise.