### PR TITLE
Rework simple capture

### DIFF
--- a/cw/cw305/capture.yaml
+++ b/cw/cw305/capture.yaml
@@ -5,8 +5,8 @@ device:
   baudrate: 115200
 spiflash:
   bin: bin/linux/spiflash
-  # FTDI USB id (vendor:product) ID and serial number can be extracted using the
-  # lsusb command.
+  # FTDI USB id (vendor:product) ID and serial number can be extracted using
+  # the lsusb command.
   dev_id: 0403:6014
   dev_sn: FT2U2SK1
 capture:
@@ -19,3 +19,5 @@ plot_capture:
   show: false
   num_traces: 100
   trace_image_filename: projects/sample_traces.html
+  # The ADC output is in the interval [-0.5, 0.5). Define safety margin.
+  amplitude_max: 0.48

--- a/cw/cw305/simple_capture_traces.py
+++ b/cw/cw305/simple_capture_traces.py
@@ -80,6 +80,11 @@ def run_capture(capture_cfg, ot, ktp):
 def plot_results(plot_cfg, project_name):
   """Plots traces from `project_name` using `plot_cfg` settings."""
   project = cw.open_project(project_name)
+
+  if len(project.waves) == 0:
+    print('Project contains no traces. Did the capture fail?')
+    return
+
   plot.save_plot_to_file(project.waves, plot_cfg['num_traces'],
                          plot_cfg['trace_image_filename'])
 

--- a/cw/cw305/util/device.py
+++ b/cw/cw305/util/device.py
@@ -42,7 +42,7 @@ class OpenTitan(object):
   def initialize_scope(self):
     """Initializes chipwhisperer scope."""
     scope = cw.scope()
-    scope.gain.db = 30
+    scope.gain.db = 27.5
     # Samples per trace - We oversample by 10x and AES is doing ~12/16 cycles per encryption.
     scope.adc.samples = 180
     scope.adc.offset = 0


### PR DESCRIPTION
This PR slightly reworks how the simple capture scripts handles cases where the ADC might saturate. Previously it just silently skipped failed captures. Now, the trace is recorded anyway. But when plotting the recorded traces, all traces are checked for samples outside a safe range and a warning is printed in that case. The user is suggested to reduce the scope gain. This allows to keep the capture script simple but gives an easy way to verify the setup before triggering a long capture run.

Also, a configurable delay is added before the capture start in order to unplug the FTDI cable to reduce noise.

This PR supersedes #21 . 