### PR TITLE
Update spiflash._Bootstrap.transfer in response to changes in chipwhisperer

### DIFF
--- a/cw/cw305/util/spiflash.py
+++ b/cw/cw305/util/spiflash.py
@@ -179,7 +179,7 @@ class _Bootstrap:
       time.sleep(self._INTER_FRAME_DELAY)
     print(f'Transferring {frame}.')
     # Acknowledgement is the same size as digests.
-    return b''.join(self._fpga_io.spi1_transfer(bytes(frame)))[:_SpiFlashFrame.DIGEST_SIZE]
+    return bytes(self._fpga_io.spi1_transfer(bytes(frame))[:_SpiFlashFrame.DIGEST_SIZE])
 
 
 class SAM3UProgrammer:


### PR DESCRIPTION
This change updates _Bootstrap.transfer to work with the recent changes in
chipwhisperer (newaetech/chipwhisperer@68f12e1).

Signed-off-by: Alphan Ulusoy <alphan@google.com>
