### PR TITLE
[docker] Add Dockerfile and supporting scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!python-requirements.txt
+!util/docker

--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -1,0 +1,77 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Docker file for OpenTitan side channel analysis and fault injection.
+
+FROM ubuntu:18.04
+
+LABEL version="0.1"
+LABEL description="OpenTitan SCA/FI image"
+LABEL maintainer="alphan@google.com"
+
+ARG USER_NAME=ot
+ARG MOUNT_DIR=/repo
+ARG TIME_ZONE=America/New_York 
+# This is convenient if we want to switch to different python version.
+# Note: numba, a chipwhisperer dependency, requires python 3.7+ but does not
+# support python 3.9 yet.
+ARG PYTHON=python3.8
+ARG VENV_PATH=/opt/venv
+
+# Use bash as the default shell.
+SHELL ["/bin/bash", "-c"]
+
+# Imstall required packages.
+# git-lfs: https://github.com/git-lfs/git-lfs/wiki/Installation#docker-recipes
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
+        git \
+        curl \
+        ca-certificates \
+        screen \
+        locales \
+        tzdata \
+        setpriv && \
+    curl -fsSL https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | DEBIAN_FRONTEND="noninteractive" bash && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y git-lfs
+
+# Set locale and time zone.
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+RUN ln -fs /usr/share/zoneinfo/"${TIME_ZONE}" /etc/localtime
+RUN dpkg-reconfigure -f noninteractive tzdata
+
+# Chipwhisperer dependencies.
+# https://chipwhisperer.readthedocs.io/en/latest/prerequisites.html
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
+    libusb-dev \
+    make
+
+# Python virtual environment and dependencies.
+# Note: Permissions are relaxed so that the user created in the entrypoint can also use `pip`.
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+    "${PYTHON}" \
+    "${PYTHON}"-dev \
+    "${PYTHON}"-distutils \
+    "${PYTHON}"-venv
+RUN "${PYTHON}" -m venv "${VENV_PATH}"
+ENV PATH="${VENV_PATH}"/bin:"${PATH}"
+ENV VIRTUAL_ENV="${VENV_PATH}"
+COPY python-requirements.txt /tmp/python-requirements.txt
+RUN pip install --upgrade pip && \
+    pip install -r /tmp/python-requirements.txt && \
+    chmod -R o=u "${VENV_PATH}";
+
+# Cleanup
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+# Entrypoint
+COPY util/docker/docker_entrypoint.sh /docker_entrypoint.sh
+RUN echo "exec /docker_entrypoint.sh '${USER_NAME}' '${MOUNT_DIR}'" > /docker_entrypoint_wrapper.sh
+RUN chmod +x /docker_entrypoint.sh /docker_entrypoint_wrapper.sh
+ENTRYPOINT /docker_entrypoint_wrapper.sh

--- a/util/docker/build_image.sh
+++ b/util/docker/build_image.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+readonly IMAGE_NAME='ot-sca'
+readonly DOCKERFILE='util/docker/Dockerfile'
+
+docker build -t ${IMAGE_NAME} -f ${DOCKERFILE} .

--- a/util/docker/docker_entrypoint.sh
+++ b/util/docker/docker_entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Entrypoint for OpenTitan SCA/FI image. This script:
+# - Creates a new non-privileged user with the same UID and GID as the owner of
+#   the host directory to avoid permission issues,
+# - Adds this user to plugdev and dialout groups to able to access
+#   chipwhisperer devices,
+# - Drops root privileges by switching to the newly created user, and
+# - Replaces the current process with a new shell.
+
+# We expect only two variables.
+if [[ "$#" -ne 2 ]]; then
+  echo "Unexpected number of parameters: $#" >&2
+  exit 1
+fi
+
+readonly USER_NAME="$1"
+readonly MOUNT_DIR="$2"
+readonly SHELL='/bin/bash'
+
+# Create a user with the same UID and GID as the owner of the mount.
+# Note: The user is also added to plugdev and dialout to be able talk to
+# chipwhisperer USB devices. IDs of these groups must match those of the
+# host system, which typically is the case.
+HOST_UID="$(stat -c '%u' "${MOUNT_DIR}")"
+readonly HOST_UID
+HOST_GID="$(stat -c '%g' "${MOUNT_DIR}")"
+readonly HOST_GID 
+echo "Creating user '${USER_NAME}' with UID=${HOST_UID}, GID=${HOST_GID}."
+groupadd -g "${HOST_GID}" "${USER_NAME}"
+useradd -u "${HOST_UID}" -g "${HOST_GID}" -m -s "${SHELL}" "${USER_NAME}"
+
+# Install git lfs
+runuser "${USER_NAME}" -c 'git lfs install' > /dev/null
+
+# Cleanup, drop privileges, and replace the current process with a new shell.
+rm /docker_entrypoint.sh /docker_entrypoint_wrapper.sh
+HOME_DIR="$(getent passwd "${USER_NAME}" | cut -d : -f 6)"
+readonly HOME_DIR
+HOME="${HOME_DIR}" exec setpriv --reuid="${HOST_UID}" --regid="${HOST_GID}" --inh-caps -all --init-group "${SHELL}"

--- a/util/docker/run_container.sh
+++ b/util/docker/run_container.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+readonly CONTAINER_WORK_DIR=/repo
+readonly CONTAINER_NAME=ot-sca
+
+function usage() {
+  cat <<USAGE
+
+Run OpenTitan SCA/FI image.
+
+Usage: $0 -d DEVICE [-d DEVICE] -m SHM_SIZE -w HOST_WORK_DIR [-h]
+ 
+  -d: Host device to be added to the container. This option can be used multiple times.
+  -m: Shared memory size (/dev/shm) of the container. Should be at least 1/3 of total memory.
+  -w: Host directory that will be mounted into the container as /repo.
+  -h: Print usage information and exit.
+
+USAGE
+}
+
+function error() {
+  echo "$1" 2>&1
+  usage
+  exit 1
+}
+
+DEVICES=()
+while getopts ':d:m:w:h' opt; do
+  case "${opt}" in
+    d)  DEVICES+=("${OPTARG}") ;;
+    m)  SHM_SIZE="${OPTARG}" ;;
+    w)  HOST_WORK_DIR="${OPTARG}" ;;
+    h)  usage; exit 0 ;;
+    :)  error "Option '-${OPTARG}' requires an argument." ;;
+    \?) error "Invalid option: '-${OPTARG}'" ;;
+    *)  error "Invalid option: '-${opt}'" ;;
+  esac
+done
+readonly DEVICES
+readonly SHM_SIZE
+readonly HOST_WORK_DIR
+
+# Make sure that there are no additional arguments.
+shift $((OPTIND-1))
+if [[ "$#" -gt 0 ]]; then
+  error "Unexpected arguments: '$*'"
+fi
+
+# Make sure that all required options are present.
+if [[ -z "${HOST_WORK_DIR}" ]] || [[ -z "${SHM_SIZE}" ]] || [[ ${#DEVICES[@]} -eq 0 ]]; then
+  error "Missing options: '-m SHM_SIZE', '-w HOST_WORK_DIR', and '-d DEVICE' are required."
+fi
+
+docker run --rm -it \
+    --shm-size "${SHM_SIZE}" \
+    -v "${HOST_WORK_DIR}":"${CONTAINER_WORK_DIR}" \
+    -w "${CONTAINER_WORK_DIR}" \
+    "${DEVICES[@]/#/--device=}" \
+    --hostname "${CONTAINER_NAME}" --name "${CONTAINER_NAME}" "${CONTAINER_NAME}"


### PR DESCRIPTION
This change adds a Dockerfile and supporting scripts to build a ready-to-use OpenTitan SCA(/FI) image.

Some details worth mentioning:
* The image includes a python virtual environment. While this is not strictly necessary, it decouples our dependencies from the base image and gives us more freedom.
* `run_container.sh` adds ChipWhisperer USB devices into the container. Thus, this image can be used for capturing traces in addition to running ot-sca python code.
* Special care has been taken to avoid permission issues: The image creates a new user at runtime with a UID and a GID that matches the UID and GID of the owner of the host directory.
* It is possible to run `pip install` in the container if an in-progress change adds a new python dependency.
* The image also includes `git-lfs` so that users can switch between branches in the container.
* This image is not intended for development, e.g. it doesn't include an editor. The main use-case is running ot-sca python code by mounting a repo folder from a host (or another container).
* `getting_started.md` is also updated.
* The image is pretty big, mostly due to the ChipWhisperer repo, which is 1.4 GB.

Looking forward to your comments.

Signed-off-by: Alphan Ulusoy <alphan@google.com>