### PR TITLE
Add WaveRunner support and batch capture script

### DIFF
--- a/cw/cw305/capture.yaml
+++ b/cw/cw305/capture.yaml
@@ -15,6 +15,9 @@ capture:
   plain_text_len_bytes: 16
   num_traces: 5000
   project_name: projects/opentitan_simple_aes
+  waverunner_ip: 192.168.1.228
+  waverunner_max_seq_traces: 2000
+  batch_prng_seed: 0
 plot_capture:
   show: false
   num_traces: 100

--- a/cw/cw305/simple_capture_traces_waverunner.py
+++ b/cw/cw305/simple_capture_traces_waverunner.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Captures traces using the 'b' (batch encryption) command and WaveRunner."""
+
+import argparse
+import random
+import time
+
+from tqdm import tqdm
+import chipwhisperer as cw
+import numpy as np
+import scared
+import yaml
+
+import simple_capture_traces as simple_capture
+from waverunner import WaveRunner
+
+
+def run_batch_capture(capture_cfg, ot, ktp):
+    """Captures traces using the 'b' (batch encryption) command and WaveRunner.
+
+    Args:
+      capture_cfg: Dictionary with capture configuration settings.
+      ot: Initialized OpenTitan target.
+      ktp: Key and plaintext generator.
+    """
+    # Ping target
+    print("Reading from FPGA using simpleserial protocol.")
+    version = None
+    while not version:
+        ot.target.write("v" + "\n")
+        time.sleep(0.5)
+        version = ot.target.read().strip()
+    print(f"Target simpleserial version: '{version}'.")
+    # Set key
+    assert ktp.fixed_key
+    key = ktp.next_key()
+    print(f"Using key: '{key.hex()}'.")
+    ot.target.simpleserial_write("k", key)
+    # Seed the target's PRNG (host's PRNG is currently seeded in main).
+    ot.target.simpleserial_write(
+        "s", capture_cfg["batch_prng_seed"].to_bytes(4, "little")
+    )
+    # Initialize waverunner
+    waverunner = WaveRunner(capture_cfg["waverunner_ip"])
+    waverunner.configure()
+    # Create the ChipWhisperer project.
+    project_file = capture_cfg["project_name"]
+    project = cw.create_project(project_file, overwrite=True)
+    # Capture traces.
+    rem_num_traces = capture_cfg["num_traces"]
+    with tqdm(total=rem_num_traces, desc="Capturing", ncols=80, unit=" traces") as pbar:
+        while rem_num_traces > 0:
+            # Determine the number of traces for this batch and arm the oscilloscope.
+            num_waves = min(rem_num_traces, capture_cfg["waverunner_max_seq_traces"])
+            waverunner.seq_num_waves = num_waves
+            waverunner.arm()
+            # Start batch encryption.
+            ot.target.simpleserial_write("b", num_waves.to_bytes(4, "little"))
+            # Transfer traces
+            waves = waverunner.wait_for_acquisition_and_transfer_waves()
+            assert waves.shape[0] == num_waves
+            # Generate plaintexts and ciphertexts for the batch.
+            # Note: Plaintexts are encrypted in parallel.
+            plaintexts = [ktp.next()[1] for _ in range(num_waves)]
+            ciphertexts = [
+                bytearray(c)
+                for c in scared.aes.base.encrypt(
+                    np.asarray(plaintexts), np.asarray(key)
+                )
+            ]
+            # Check the last ciphertext of this batch to make sure we are in sync.
+            actual_last_ciphertext = ot.target.simpleserial_read("r", 16, ack=False)
+            expected_last_ciphertext = ciphertexts[-1]
+            assert actual_last_ciphertext == expected_last_ciphertext, (
+                f"Incorrect encryption result!\n"
+                f"actual: {actual_last_ciphertext}\n"
+                f"expected: {expected_last_ciphertext}"
+            )
+            # Add traces of this batch to the project.
+            # TODO: This seems to scale with the total number of traces, not just the number of
+            #       new traces. We should take a closer look.
+            for wave, plaintext, ciphertext in zip(waves, plaintexts, ciphertexts):
+                project.traces.append(
+                    cw.common.traces.Trace(wave, plaintext, bytearray(ciphertext), key)
+                )
+            # Update the loop variable and the progress bar.
+            rem_num_traces -= num_waves
+            pbar.update(num_waves)
+    assert len(project.traces) == capture_cfg["num_traces"]
+    project.save()
+
+
+def main():
+    """Loads the configuration file, captures and plots traces."""
+    with open("capture.yaml") as f:
+        cfg = yaml.safe_load(f)
+    ot = simple_capture.initialize_capture(cfg["device"], cfg["spiflash"])
+    # Seed the PRNG.
+    # TODO: Replace this with a dedicated PRNG to avoid other packages breaking
+    # our code.
+    random.seed(cfg["capture"]["batch_prng_seed"])
+    # Configure the key and plaintext generator.
+    ktp = cw.ktp.Basic()
+    ktp.key_len = cfg["capture"]["key_len_bytes"]
+    ktp.text_len = cfg["capture"]["plain_text_len_bytes"]
+    ot.target.output_len = cfg["capture"]["plain_text_len_bytes"]
+    # Capture traces.
+    run_batch_capture(cfg["capture"], ot, ktp)
+    # Plot a few traces.
+    project_name = cfg["capture"]["project_name"]
+    simple_capture.plot_results(cfg["plot_capture"], project_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/cw/cw305/waverunner.py
+++ b/cw/cw305/waverunner.py
@@ -1,0 +1,250 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Support for capturing traces using LeCroy WaveRunner 9104."""
+
+import logging
+import re
+
+import numpy as np
+import vxi11
+
+
+class _Timeout:
+    """Helper class for setting scoped timeout values."""
+
+    def __init__(self, instr, timeout):
+        self._instr = instr
+        self._orig_timeout = self._instr.timeout
+        self._instr.timeout = timeout
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._instr.timeout = self._orig_timeout
+
+
+class WaveRunner:
+    """Class for capturing traces using a WaveRunner oscilloscope.
+
+    This class operates the oscilloscope in sequence mode to improve performance and in
+    2-channel mode to maximize sampling rate. Trigger and power signals must be
+    connected to channels 2 and 3, respectively.
+
+    When in sequence mode, the oscilloscope captures a total of `seq_num_waves` waves
+    each starting at a trigger event. This is much more efficient than sending a
+    separate command for each wave.
+
+    This class is only tested to work with WaveRunner 9104 series.
+
+    For more information on the commands used in this module please see:
+    - Operator's Manual WaveRunner 9000 and WaveRunner 8000-R Oscilloscopes
+        (http://cdn.teledynelecroy.com/files/manuals/waverunner-9000-operators-manual.pdf)
+    - MAUI Oscilloscopes Remote Control and Automation Manual
+        (http://cdn.teledynelecroy.com/files/manuals/maui-remote-control-and-automation-manual.pdf)
+
+    Typical usage:
+    >>> waverunner = WaveRunner('192.168.1.227')
+    >>> waverunner.configure()
+    >>> while foo:
+    >>>     ...
+    >>>     waverunner.seq_num_waves = seq_num_waves
+    >>>     waverunner.arm()
+    >>>     waves = waverunner.wait_for_acquisition_and_transfer_waves()
+    >>>     ...
+
+    Attributes:
+        seq_num_waves: Number of waves per sequence.
+    """
+
+    def __init__(self, ip_addr):
+        """Inits a WaveRunner.
+
+        Connects to the oscilloscope, populates and prints device information.
+
+        Args:
+            ip_addr: IP address of the oscilloscope.
+        """
+        self._ip_addr = ip_addr
+        self.seq_num_waves = 1000
+        self._num_samples = 180
+        self._instr = vxi11.Instrument(self._ip_addr)
+        self._populate_device_info()
+        self._print_device_info()
+
+    def _write(self, cmd):
+        self._instr.write(cmd)
+
+    def _ask(self, cmd):
+        return self._instr.ask(cmd)
+
+    def _ask_raw(self, cmd):
+        return self._instr.ask_raw(cmd)
+
+    def _populate_device_info(self):
+        manufacturer, model, serial, version = re.match(
+            "([^,]*),([^,]*),([^,]*),([^,]*)", self._ask("*IDN?")
+        ).groups()
+        opts = ", ".join(self._ask("*OPT?").split(","))
+        self._device_info = {
+            "manufacturer": manufacturer,
+            "model": model,
+            "serial": serial,
+            "version": version,
+            "opts": opts,
+        }
+
+    def _print_device_info(self):
+        def print_info(manufacturer, model, serial, version, opts):
+            # TODO: logging
+            print(
+                f"Connected to {manufacturer} {model} (ip: {self._ip_addr}, serial: {serial}, version: {version}, options: {opts})"
+            )
+
+        print_info(**self._device_info)
+
+    def _default_setup(self):
+        self._instr.timeout = 10
+        # Reset the app and wait until it's done.
+        self._write("vbs 'app.settodefaultsetup'")
+        self._ask("vbs? 'return=app.WaitUntilIdle(1)'")
+        # Prioritize analysis over rendering in the app.
+        self._write("vbs 'app.Preferences.Performance = \"Analysis\"'")
+        commands = [
+            # Stop the trigger.
+            "TRMD STOP",
+            # Hide all traces for better performance.
+            "C1:TRA OFF",
+            "C2:TRA OFF",
+            "C3:TRA OFF",
+            "C4:TRA OFF",
+            # Single grid.
+            "GRID SINGLE",
+            # Use shorter responses.
+            "CHDR OFF",
+            # Wait until all operations are complete.
+            "*OPC?",
+        ]
+        res = self._ask(";".join(commands))
+        assert res == "1"
+
+    def _configure_power_channel(self):
+        commands = [
+            # DC coupling, 1 Mohm.
+            "C3:CPL D1M",
+            "C3:VDIV 15MV",
+            "C3:OFST 25MV",
+        ]
+        self._write(";".join(commands))
+        self._write("vbs 'app.Acquisition.C3.BandwidthLimit = \"200MHz\"'")
+        # Noise filtering - reduces bandwidth.
+        self._write("vbs 'app.Acquisition.C3.EnhanceResType = \"2.5bits\"'")
+
+    def _configure_trigger_channel(self):
+        commands = [
+            # DC coupling, 1 Mohm.
+            "C2:CPL D1M",
+            # 0.75 V/div, -1.75 V offset.
+            "C2:VDIV 0.75V",
+            "C2:OFST -1.75V",
+        ]
+        self._write(";".join(commands))
+        self._write("vbs 'app.Acquisition.C2.BandwidthLimit = \"200MHz\"'")
+
+    def _configure_trigger(self):
+        commands = [
+            # Select trigger: edge, channel 2, no hold-off.
+            "TRSE EDGE,SR,C2,HT,OFF",
+            # Rising edge.
+            "C2:TRSL POS",
+            # DC coupling.
+            "C2:TRCP DC",
+            # Trigger level.
+            "C2:TRLV 1.5",
+        ]
+        self._write(";".join(commands))
+
+    def _configure_timebase(self):
+        commands = [
+            "TDIV 200NS",
+            # Trigger delay: Trigger is centered by default. Move to the left to
+            # include the samples that we are interested in.
+            # Note: This number is tuned to align WaveRunner traces with ChipWhisperer
+            # traces.
+            "TRDL -940NS",
+        ]
+        self._write(";".join(commands))
+
+    def _configure_acquisition(self):
+        # Only use channels 2 and 3 to maximize sampling rate.
+        self._write("vbs 'app.Acquisition.Horizontal.ActiveChannels = \"2\"'")
+        self._write("vbs 'app.Acquisition.Horizontal.Maximize = \"FixedSampleRate\"'")
+        self._write("vbs 'app.Acquisition.Horizontal.SampleRate = \"1 GS/s\"'")
+
+    def _configure_waveform_transfer(self):
+        commands = [
+            # SP: decimation, 10 for 1 GS/s -> 100 MS/s.
+            # NP: number of points, self._num_samples.
+            # FP: first point (without decimation).
+            # SN: All sequences: 0
+            f"WFSU SP,10,NP,{self._num_samples},FP,0,SN,0",
+            # Data format: with DEF9 header, bytes (8-bit signed integers), binary encoding.
+            # TODO: byte vs. word.
+            "CFMT DEF9,BYTE,BIN",
+            # LSB first.
+            "CORD LO",
+        ]
+        self._write(";".join(commands))
+
+    def configure(self):
+        """Configures the oscilloscope for acquisition."""
+        self._default_setup()
+        self._configure_power_channel()
+        self._configure_trigger_channel()
+        self._configure_trigger()
+        self._configure_timebase()
+        self._configure_acquisition()
+        self._configure_waveform_transfer()
+
+    def arm(self):
+        """Arms the oscilloscope in sequence mode."""
+        commands = [
+            f"SEQ ON,{self.seq_num_waves}",
+            "TRMD SINGLE",
+            "*OPC?",
+        ]
+        res = self._ask(";".join(commands))
+        assert res == "1"
+
+    def _parse_waveform(self, data):
+        # Packet format: DAT1,#9000002002<SAMPLES>
+        len_ = int(data[7:16])
+        # Note: We use frombufer to minimize processing overhead.
+        waves = np.frombuffer(data, np.int8, int(len_), 16)
+        waves = waves.reshape((self.seq_num_waves, self._num_samples))
+        return waves
+
+    def wait_for_acquisition_and_transfer_waves(self):
+        """Waits until the acquisition is complete and transfers waveforms.
+
+        Returns:
+            Waveforms.
+        """
+        # Don't process commands until the acquisition is complete and wait until
+        # processing is complete.
+        res = self._ask("WAIT 10;*OPC?")
+        assert res == "1"
+        # Transfer and parse waveform data.
+        data = self._ask_raw(b"C3:WF? DAT1")
+        waves = self._parse_waveform(data)
+        return waves
+
+    def display_message(self, msg):
+        """Displays a message on the oscilloscope."""
+        self._write(f'MSG "{msg}"')
+
+    def buzz(self):
+        """Activates the built-in buzzer."""
+        self._write("BUZZ BEEP")

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -8,6 +8,8 @@ codetiming
 more-itertools
 networkx
 pycryptodome
+# TODO: Use pyvisa instead after switching to a dedicated PRNG
+python-vxi11
 pyyaml
 ray
 scared


### PR DESCRIPTION
This change adds support for capturing traces using a LeCroy WaveRunner 9104 and a new script that captures traces using the new 'b' (batch encrypt) command.

As I mentioned earlier, WaveRunner has several settings that we should evaluate. For the sake of simplicity, most of the parameters are hardcoded for now in `waverunner.py`. I thought it would be better to postpone the decision on which parameters should be fixed and which should be tunable when we start working on the CLI (and the refactoring that will go with it). I guess the most important parameters are sampling rate and noise filtering which are set to 1 GS/s down to 100 MS/s with 10x sparsing + 2.5bits ERes (enhanced resolution, i.e. noise filtering). 2.5bits ERes is a bit extreme and significantly reduces the bandwidth (-3dB @ 14.50 MHz according to the oscilloscope) but it performed better than smaller values in the ceca attack so I decided to leave it as-is. This obviously results in much smoother traces when compared to chipwhisperer (top: waverunner, bottom: chipwhisperer):

![image](https://user-images.githubusercontent.com/57949550/107723400-0a21dc80-6caf-11eb-82a6-962b8cc104b6.png)

![image](https://user-images.githubusercontent.com/57949550/107723425-1443db00-6caf-11eb-9f38-b32f3dbf0650.png)

I confirmed that these changes work using an older `aes_serial` binary and the bitstream in the ot-sca repo (will try building these from opentitan:master next). This change lets us capture traces at a rate of ~1200 traces/s:
```
$ ./simple_capture_traces_waverunner.py
Connecting and loading FPGA
Initializing PLL1
Programming OpenTitan with "objs/aes_serial_fpga_nexysvideo.bin"...
Transferring frame 0x00000000 @ 0x00000000.
...
Transferring frame 0x8000000B @ 0x00002A48.
Serial baud rate = 38400
Serial baud rate = 115200
Scope setup with sampling rate 100003063.0 S/s
Reading from FPGA using simpleserial protocol.
Target simpleserial version: 'z01'.
Using key: '2b7e151628aed2a6abf7158809cf4f3c'.
Connected to LECROY WAVERUNNER9104 (ip: 192.168.1.228, serial: LCRY4701N40366, version: 9.1.0, options: HDTV, JTA2, XDEV, XWEB)
Capturing: 100%|███████████████| 1000000/1000000 [13:18<00:00, 1252.54 traces/s]
```

I also confirmed that we can recover the key with the new traces:
```
$ ./ceca.py -f projects/opentitan_simple_aes -n 1000000 -w 8 -a 110 130 -d output -s 3
2021-02-11 21:04:07,420 INFO services.py:1171 -- View the Ray dashboard at http://127.0.0.1:8265
2021-02-11 21:04:10,909 INFO ceca.py:492 -- Will use 982919 traces (98.3% of all traces)
2021-02-11 21:04:11,656 INFO _timer.py:57 -- compute_pairwise_diffs_and_scores took 0.3s
2021-02-11 21:04:11,657 INFO ceca.py:501 -- Difference values (delta_0_i): [  0 196  41 120  25  62 245  89  49 239 220  24 102 179 220 118]
2021-02-11 21:04:11,734 INFO ceca.py:505 -- Recovered AES key: 2b7e151628aed2a6abf7158809cf4f3c
2021-02-11 21:04:11,735 INFO _timer.py:57 -- perform_attack took 2.9s
2021-02-11 21:04:11,735 INFO _timer.py:57 -- main took 4.9s
```

Initially I was planning to refactor the current capture script, but I thought it would be better to just add a new script without touching the one that everyone relies on. Again, something to tackle when we start working on the CLI.

Signed-off-by: Alphan Ulusoy <alphan@google.com>