### PR TITLE
Update FPGA bitstream and aes_serial binary

### DIFF
--- a/cw/cw305/objs/aes_serial_fpga_nexysvideo.bin
+++ b/cw/cw305/objs/aes_serial_fpga_nexysvideo.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8166d29a9c98f3cf29ead157d29f044c2c1a6a300340a94bf29f82eb05aa781b
-size 12128
+oid sha256:6316c49fdfeb8b0858a490470e45feeb778f5a877bb3cee73928c2b2d3754fda
+size 10800

--- a/cw/cw305/objs/lowrisc_systems_top_earlgrey_cw305_0.1.bit
+++ b/cw/cw305/objs/lowrisc_systems_top_earlgrey_cw305_0.1.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:367aa4571ed49e877c483fde4fbda309832eee87603c2c585f8f9413f5c27b51
-size 3825903
+oid sha256:50e9e844db360685a2c0a7346f10dce6dd32aa1b43d924e0ef4b2cf845dbaa3a
+size 3825911

--- a/cw/cw305/simple_capture_traces.py
+++ b/cw/cw305/simple_capture_traces.py
@@ -60,7 +60,7 @@ def run_capture(capture_cfg, ot, ktp):
 
   for i in tqdm(range(capture_cfg['num_traces']), desc='Capturing', ncols=80):
     key, text = ktp.next()
-    ret = cw.capture_trace(ot.scope, ot.target, text, key)
+    ret = cw.capture_trace(ot.scope, ot.target, text, key, ack=False)
     if not ret:
       print('Failed capture')
       continue

--- a/cw/cw305/util/device.py
+++ b/cw/cw305/util/device.py
@@ -38,7 +38,7 @@ class OpenTitan(object):
   def initialize_scope(self):
     """Initializes chipwhisperer scope."""
     scope = cw.scope()
-    scope.gain.db = 27.5
+    scope.gain.db = 12
     # Samples per trace - We oversample by 10x and AES is doing ~12/16 cycles per encryption.
     scope.adc.samples = 180
     scope.adc.offset = 0

--- a/cw/cw305/waverunner.py
+++ b/cw/cw305/waverunner.py
@@ -134,8 +134,8 @@ class WaveRunner:
         commands = [
             # DC coupling, 1 Mohm.
             "C3:CPL D1M",
-            "C3:VDIV 15MV",
-            "C3:OFST 25MV",
+            "C3:VDIV 40MV",
+            "C3:OFST 140MV",
         ]
         self._write(";".join(commands))
         self._write("vbs 'app.Acquisition.C3.BandwidthLimit = \"200MHz\"'")
@@ -173,7 +173,7 @@ class WaveRunner:
             # include the samples that we are interested in.
             # Note: This number is tuned to align WaveRunner traces with ChipWhisperer
             # traces.
-            "TRDL -940NS",
+            "TRDL -960NS",
         ]
         self._write(";".join(commands))
 


### PR DESCRIPTION
This change updates the FPGA bitstream and `aes_serial` binary. Since I wasn't able to generate the bitstream from the tip (lowRISC/opentitan@445fe3132), both files were built by cherry-picking the relevant `aes_serial` updates (lowRISC/opentitan@675e9497b and lowRISC/opentitan@cbbc70fe2) on top of lowRISC/opentitan@71d98f8e (last known good commit).

This change also
  * Removes acks during capture (see cw/cw305/simple_capture_traces.py) and adjusts the scope gain in cw/cw305/util/device.py (not sure if the new value will be the best for everyone).
  * Adjusts the vertical scale and the trigger offset of waverunner.

Here's how the traces look (top: chipwhisperer, bottom: waverunner):

![image](https://user-images.githubusercontent.com/57949550/107858591-01dab600-6e03-11eb-840f-1964000401cc.png)

![image](https://user-images.githubusercontent.com/57949550/107858585-f9827b00-6e02-11eb-9492-258082455d9f.png)

 I also verified that all capture scripts work with the new binaries and we can recover the key (tried only using waverunner):

```
$ ./simple_capture_traces_waverunner.py 
Connecting and loading FPGA
Initializing PLL1
Programming OpenTitan with "objs/aes_serial_fpga_nexysvideo.bin"...
Transferring frame 0x00000000 @ 0x00000000.
...
Transferring frame 0x8000000B @ 0x00002A48.
Serial baud rate = 38400
Serial baud rate = 115200
Scope setup with sampling rate 100003051.0 S/s
Reading from FPGA using simpleserial protocol.
Target simpleserial version: 'z01'.
Using key: '2b7e151628aed2a6abf7158809cf4f3c'.
Connected to LECROY WAVERUNNER9104 (ip: 192.168.1.228, serial: LCRY4701N40366, version: 9.1.0, options: HDTV, JTA2, XDEV, XWEB)
Capturing: 100%|███████████████| 2000000/2000000 [30:06<00:00, 1107.05 traces/s]
WARNING: Some traces have samples outside the range (-0.48, 0.48).
         The ADC has a max range of [-0.5, 0.5) and might saturate.
         It is recommended to reduce the scope gain (see device.py).

$ ./ceca.py -f projects/opentitan_simple_aes -n 1500000 -a 115 120 -w 8 -d output -s 3
2021-02-13 13:45:12,162 INFO services.py:1171 -- View the Ray dashboard at http://127.0.0.1:8265
2021-02-13 13:45:16,600 INFO ceca.py:492 -- Will use 1490514 traces (99.4% of all traces)
2021-02-13 13:45:17,485 INFO _timer.py:57 -- compute_pairwise_diffs_and_scores took 0.3s
2021-02-13 13:45:17,486 INFO ceca.py:501 -- Difference values (delta_0_i): [  0 196  41 120  25  62 245  89  49 239 220  24 102 179 220 118]
2021-02-13 13:45:17,561 INFO ceca.py:505 -- Recovered AES key: 2b7e151628aed2a6abf7158809cf4f3c
2021-02-13 13:45:17,561 INFO _timer.py:57 -- perform_attack took 4.0s
2021-02-13 13:45:17,561 INFO _timer.py:57 -- main took 5.9s
```

I wish cw-lite had a vertical offset setting, it would considerably improve our vertical resolution (added to meeting notes as an agenda item).

Signed-off-by: Alphan Ulusoy <alphan@google.com>