### PR TITLE
Ping target with 'v' until it responds.

### DIFF
--- a/cw/cw305/simple_capture_traces_waverunner.py
+++ b/cw/cw305/simple_capture_traces_waverunner.py
@@ -27,14 +27,6 @@ def run_batch_capture(capture_cfg, ot, ktp):
       ot: Initialized OpenTitan target.
       ktp: Key and plaintext generator.
     """
-    # Ping target
-    print("Reading from FPGA using simpleserial protocol.")
-    version = None
-    while not version:
-        ot.target.write("v" + "\n")
-        time.sleep(0.5)
-        version = ot.target.read().strip()
-    print(f"Target simpleserial version: '{version}'.")
     # Set key
     assert ktp.fixed_key
     key = ktp.next_key()


### PR DESCRIPTION
This is related to #24 and doesn't fix the underlying issue (I'm still not sure what it is, could be the `flush` after setting the baudrate in `initialize_target` or something else) but I thought it would be a good idea to wait until receiving a proper response from the target before starting the capture.