### PR TITLE
Maintain high capture rate for long batch captures

### DIFF
--- a/cw/cw305/simple_capture_traces_batch.py
+++ b/cw/cw305/simple_capture_traces_batch.py
@@ -97,6 +97,13 @@ def run_batch_capture(capture_cfg, ot, ktp, scope):
                 f"actual: {actual_last_ciphertext}\n"
                 f"expected: {expected_last_ciphertext}"
             )
+            # Make sure to allocate sufficient memory for the storage segment array during the
+            # first resize operation. By default, the ChipWhisperer API starts every new segment
+            # with 1 trace and then increases it on demand by 25 traces at a time. This results in
+            # frequent array resizing and decreasing capture rate.
+            # See addWave() in chipwhisperer/common/traces/_base.py.
+            if project.traces.cur_seg.tracehint < project.traces.seg_len:
+                project.traces.cur_seg.setTraceHint(project.traces.seg_len)
             # Add traces of this batch to the project.
             # TODO: This seems to scale with the total number of traces, not just the number of
             #       new traces. We should take a closer look.

--- a/cw/cw305/simple_capture_traces_batch.py
+++ b/cw/cw305/simple_capture_traces_batch.py
@@ -14,7 +14,6 @@ SCOPE must be either "cw_lite" or "waverunner".
 
 import argparse
 import random
-import time
 
 from tqdm import tqdm
 import chipwhisperer as cw


### PR DESCRIPTION
This PR contains two commits in order to increase the capture rate for long batch captures.
1. Frequent storage segment array resizing is avoided by setting the hint value to the known storage segment size (a project parameter).
2. During capture, `disable` all except for the latest two storage segments to keep the run time of the `append()` function approximately constant. By default, it increases linearly with the number of traces captured.

With these changes it is possible to maintain high capture rates up to millions of traces. Further changes are probably needed to avoid memory limitations. Currently everything is kept in memory during a capture and traces are written to disk only at the very end. I've opened an issue newaetech/chipwhisperer#344 in the hope of getting some further advice.