### PR TITLE
Add SHA3/KMAC capture support using Typer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 cw/cw305/objs/aes_serial_fpga_nexysvideo.bin filter=lfs diff=lfs merge=lfs -text
 doc/sample_traces.png filter=lfs diff=lfs merge=lfs -text
 cw/cw305/objs/lowrisc_systems_top_englishbreakfast_cw305_0.1.bit filter=lfs diff=lfs merge=lfs -text
+cw/cw305/objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit filter=lfs diff=lfs merge=lfs -text
+cw/cw305/objs/sha3_serial_fpga_cw310.bin filter=lfs diff=lfs merge=lfs -text
+cw/cw305/objs/aes_serial_fpga_cw310.bin filter=lfs diff=lfs merge=lfs -text

--- a/cw/cw305/capture_aes.yaml
+++ b/cw/cw305/capture_aes.yaml
@@ -16,7 +16,7 @@ capture:
   waverunner_ip: 192.168.1.228
   batch_prng_seed: 0
 plot_capture:
-  show: false
+  show: true
   num_traces: 50
   trace_image_filename: projects/sample_traces.html
   # The ADC output is in the interval [-0.5, 0.5). Define safety margin.

--- a/cw/cw305/capture_sha3.yaml
+++ b/cw/cw305/capture_sha3.yaml
@@ -1,0 +1,20 @@
+device:
+  fpga_bitstream: objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit
+  fw_bin: objs/sha3_serial_fpga_cw310.bin
+  pll_frequency: 100000000
+  baudrate: 115200
+capture:
+  key_len_bytes: 16
+  plain_text_len_bytes: 16
+  num_samples: 8000
+  scope_gain: 23
+  num_traces: 100
+  project_name: projects/opentitan_simple_sha3
+  waverunner_ip: 192.168.1.228
+  batch_prng_seed: 0
+plot_capture:
+  show: true
+  num_traces: 100
+  trace_image_filename: projects/sample_traces_sha3.html
+  # The ADC output is in the interval [-0.5, 0.5). Define safety margin.
+  amplitude_max: 0.48

--- a/cw/cw305/mix_columns_capture.py
+++ b/cw/cw305/mix_columns_capture.py
@@ -16,7 +16,7 @@ import yaml
 import simple_capture_traces as cp
 
 if __name__ == "__main__":
-  with open('capture.yaml') as f:
+  with open('capture_aes.yaml') as f:
     cfg_file = yaml.load(f, Loader=yaml.FullLoader)
   ot = cp.initialize_capture(cfg_file['device'])
   ot.target.output_len = cfg_file['capture']['plain_text_len_bytes']

--- a/cw/cw305/mix_columns_capture.py
+++ b/cw/cw305/mix_columns_capture.py
@@ -18,8 +18,7 @@ import simple_capture_traces as cp
 if __name__ == "__main__":
   with open('capture_aes.yaml') as f:
     cfg_file = yaml.load(f, Loader=yaml.FullLoader)
-  ot = cp.initialize_capture(cfg_file['device'])
-  ot.target.output_len = cfg_file['capture']['plain_text_len_bytes']
+  ot = cp.initialize_capture(cfg_file['device'], cfg_file['capture'])
 
   # Key and plaintext generator
   ktp = cw.ktp.VarVec()

--- a/cw/cw305/objs/aes_serial_fpga_cw310.bin
+++ b/cw/cw305/objs/aes_serial_fpga_cw310.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ce46b1a6720729dc77382b9593095f4eb62d59e9dad70111cee453b3cd05484
+size 10280

--- a/cw/cw305/objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit
+++ b/cw/cw305/objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0166f1afdb206fc368061abf3099c23f03683720b1f01c19567c09d32baae105
+size 15878032

--- a/cw/cw305/objs/sha3_serial_fpga_cw310.bin
+++ b/cw/cw305/objs/sha3_serial_fpga_cw310.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aca3e1d441466078fc77e1f70698b8bb66d8a911a5acc2f6a2fffaa143691951
+size 9632

--- a/cw/cw305/simple_capture_traces.py
+++ b/cw/cw305/simple_capture_traces.py
@@ -23,7 +23,8 @@ def initialize_capture(device_cfg, capture_cfg):
                           device_cfg['pll_frequency'],
                           device_cfg['baudrate'],
                           capture_cfg['scope_gain'],
-                          capture_cfg['num_samples'])
+                          capture_cfg['num_samples'],
+                          capture_cfg['plain_text_len_bytes'])
     print(f'Scope setup with sampling rate {ot.scope.clock.adc_rate} S/s')
     # Ping target
     print('Reading from FPGA using simpleserial protocol.')
@@ -132,7 +133,6 @@ if __name__ == "__main__":
     ktp = cw.ktp.Basic()
     ktp.key_len = cfg_file['capture']['key_len_bytes']
     ktp.text_len = cfg_file['capture']['plain_text_len_bytes']
-    ot.target.output_len = cfg_file['capture']['plain_text_len_bytes']
 
     run_capture(cfg_file['capture'], ot, ktp)
 

--- a/cw/cw305/simple_capture_traces.py
+++ b/cw/cw305/simple_capture_traces.py
@@ -9,36 +9,21 @@ import numpy as np
 import time
 from tqdm import tqdm
 import yaml
-import re
 
 import chipwhisperer as cw
 
 from util import device
 from util import plot
-from vendor.lowrisc_opentitan import cw_spiflash
 
 
 def initialize_capture(device_cfg, capture_cfg):
     """Initialize capture."""
-    # Extract target board type from bitstream name.
-    m = re.search('cw305|cw310', device_cfg['fpga_bitstream'])
-    if m:
-        if m.group() == 'cw305':
-            board = 'CW305'
-        else:
-            assert m.group() == 'cw310'
-            board = 'CW310'
-    else:
-        raise ValueError('Could not infer target board type from bistream name')
-    fw_programmer = cw_spiflash.SPIProgrammer(device_cfg['fw_bin'], board)
-
-    ot = device.OpenTitan(fw_programmer,
-                          device_cfg['fpga_bitstream'],
+    ot = device.OpenTitan(device_cfg['fpga_bitstream'],
+                          device_cfg['fw_bin'],
                           device_cfg['pll_frequency'],
                           device_cfg['baudrate'],
                           capture_cfg['scope_gain'],
-                          capture_cfg['num_samples'],
-                          board)
+                          capture_cfg['num_samples'])
     print(f'Scope setup with sampling rate {ot.scope.clock.adc_rate} S/s')
     # Ping target
     print('Reading from FPGA using simpleserial protocol.')

--- a/cw/cw305/simple_capture_traces.py
+++ b/cw/cw305/simple_capture_traces.py
@@ -9,22 +9,34 @@ import numpy as np
 import time
 from tqdm import tqdm
 import yaml
+from types import SimpleNamespace
+import typer
+from pathlib import Path
 
 import chipwhisperer as cw
 
 from util import device
 from util import plot
 
+app = typer.Typer(add_completion=False)
+# To be able to define subcommands for the "capture" command.
+app_capture = typer.Typer()
+app.add_typer(app_capture, name="capture", help="Capture traces for SCA")
+# Shared options for "capture aes" and "capture sha3".
+opt_num_traces = typer.Option(None, help="Number of traces to capture.")
+opt_plot_traces = typer.Option(None, help="Number of traces to plot.")
 
+
+# Note: initialize_capture and plot_results are also used by other scripts.
 def initialize_capture(device_cfg, capture_cfg):
     """Initialize capture."""
-    ot = device.OpenTitan(device_cfg['fpga_bitstream'],
-                          device_cfg['fw_bin'],
-                          device_cfg['pll_frequency'],
-                          device_cfg['baudrate'],
-                          capture_cfg['scope_gain'],
-                          capture_cfg['num_samples'],
-                          capture_cfg['plain_text_len_bytes'])
+    ot = device.OpenTitan(device_cfg["fpga_bitstream"],
+                          device_cfg["fw_bin"],
+                          device_cfg["pll_frequency"],
+                          device_cfg["baudrate"],
+                          capture_cfg["scope_gain"],
+                          capture_cfg["num_samples"],
+                          capture_cfg["plain_text_len_bytes"])
     print(f'Scope setup with sampling rate {ot.scope.clock.adc_rate} S/s')
     # Ping target
     print('Reading from FPGA using simpleserial protocol.')
@@ -32,49 +44,14 @@ def initialize_capture(device_cfg, capture_cfg):
     ping_cnt = 0
     while not version:
         if ping_cnt == 3:
-            raise RuntimeError(f'No response from the target (attempts: {ping_cnt}).')
+            raise RuntimeError(
+                f'No response from the target (attempts: {ping_cnt}).')
         ot.target.write('v' + '\n')
         ping_cnt += 1
         time.sleep(0.5)
         version = ot.target.read().strip()
     print(f'Target simpleserial version: {version} (attempts: {ping_cnt}).')
     return ot
-
-
-def run_capture(capture_cfg, ot, ktp):
-    """Run ChipWhisperer capture.
-
-    Args:
-      capture_cfg: Dictionary with capture configuration settings.
-      ot: Initialized OpenTitan target.
-      ktp: Key and plaintext generator.
-    """
-    key, text = ktp.next()
-
-    cipher = AES.new(bytes(key), AES.MODE_ECB)
-    print(f'Using key: {binascii.b2a_hex(bytes(key))}')
-
-    project_file = capture_cfg['project_name']
-    project = cw.create_project(project_file, overwrite=True)
-
-    for i in tqdm(range(capture_cfg['num_traces']), desc='Capturing', ncols=80):
-        key, text = ktp.next()
-        ret = cw.capture_trace(ot.scope, ot.target, text, key, ack=False)
-        if not ret:
-            print('Failed capture')
-            continue
-
-        expected = binascii.b2a_hex(cipher.encrypt(bytes(text)))
-        got = binascii.b2a_hex(ret.textout)
-        assert (got == expected), (
-            f'Incorrect encryption result!\ngot: {got}\nexpected: {expected}\n'
-        )
-
-        project.traces.append(ret)
-
-        ot.target.flush()
-
-    project.save()
 
 
 def plot_results(plot_cfg, project_name):
@@ -87,54 +64,148 @@ def plot_results(plot_cfg, project_name):
 
     # The ADC output is in the interval [-0.5, 0.5). Check that the recorded
     # traces are within that range with some safety margin.
-    if not (np.all(np.greater(project.waves, -plot_cfg['amplitude_max'])) and
-            np.all(np.less(project.waves, plot_cfg['amplitude_max']))):
+    if not (np.all(np.greater(project.waves, -plot_cfg["amplitude_max"]))
+            and np.all(np.less(project.waves, plot_cfg["amplitude_max"]))):
         print('WARNING: Some traces have samples outside the range (' +
-              str(-plot_cfg['amplitude_max']) + ', ' +
-              str(plot_cfg['amplitude_max']) + ').')
-        print('         The ADC has a max range of [-0.5, 0.5) and might saturate.')
-        print('         It is recommended to reduce the scope gain (see device.py).')
+              str(-plot_cfg["amplitude_max"]) + ', ' +
+              str(plot_cfg["amplitude_max"]) + ').')
+        print('The ADC has a max range of [-0.5, 0.5) and might saturate.')
+        print('It is recommended to reduce the scope gain (see device.py).')
 
-    plot.save_plot_to_file(project.waves, plot_cfg['num_traces'],
-                           plot_cfg['trace_image_filename'])
+    plot.save_plot_to_file(project.waves, plot_cfg["num_traces"],
+                           plot_cfg["trace_image_filename"])
+    print(
+        f'Created plot with {plot_cfg["num_traces"]} traces: {Path(plot_cfg["trace_image_filename"]).resolve()}'
+    )
 
 
-def parse_args():
-    """Parse command line arguments."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--num-traces',
-                        '-n',
-                        type=int,
-                        help="Override number of traces.")
-    parser.add_argument('--plot-traces',
-                        '-p',
-                        type=int,
-                        help="Plot number of traces.")
-    args = parser.parse_args()
-    return args
+@app.command()
+def init(ctx: typer.Context):
+    """Initalize target for SCA."""
+    initialize_capture(ctx.obj.cfg["device"], ctx.obj.cfg["capture"])
+
+
+def capture_init(ctx, num_traces, plot_traces):
+    """Initializes the user data stored in the context and programs the target."""
+    cfg = ctx.obj.cfg
+    if num_traces:
+        cfg["capture"]["num_traces"] = num_traces
+
+    if plot_traces:
+        cfg["plot_capture"]["show"] = True
+        cfg["plot_capture"]["num_traces"] = plot_traces
+
+    # Key and plaintext generator
+    ctx.obj.ktp = cw.ktp.Basic()
+    ctx.obj.ktp.key_len = cfg["capture"]["key_len_bytes"]
+    ctx.obj.ktp.text_len = cfg["capture"]["plain_text_len_bytes"]
+
+    ctx.obj.ot = initialize_capture(cfg["device"], cfg["capture"])
+
+
+def capture_loop(trace_gen, capture_cfg):
+    """Main capture loop.
+
+    Args:
+      trace_gen: A trace generator.
+      capture_cfg: Capture configuration.
+    """
+    project = cw.create_project(capture_cfg["project_name"], overwrite=True)
+    for _ in tqdm(range(capture_cfg["num_traces"]), desc='Capturing', ncols=80):
+        project.traces.append(next(trace_gen))
+    project.save()
+
+
+def capture_end(cfg):
+    if cfg["plot_capture"]["show"]:
+        plot_results(cfg["plot_capture"], cfg["capture"]["project_name"])
+
+
+def capture_aes(ot, ktp):
+    """A generator for capturing AES traces.
+
+    Args:
+      ot: Initialized OpenTitan target.
+      ktp: Key and plaintext generator.
+    """
+    key, _ = ktp.next()
+    tqdm.write(f'Using key: {binascii.b2a_hex(bytes(key))}')
+    cipher = AES.new(bytes(key), AES.MODE_ECB)
+    while True:
+        _, text = ktp.next()
+        ret = cw.capture_trace(ot.scope, ot.target, text, key, ack=False)
+        if not ret:
+            raise RuntimeError('Capture failed.')
+        expected = binascii.b2a_hex(cipher.encrypt(bytes(text)))
+        got = binascii.b2a_hex(ret.textout)
+        if got != expected:
+            raise RuntimeError(f'Bad ciphertext: {got} != {expected}.')
+        yield ret
+
+
+@app_capture.command()
+def aes(ctx: typer.Context,
+        num_traces: int = opt_num_traces,
+        plot_traces: int = opt_plot_traces):
+    """Capture AES traces from a target that runs the `aes_serial` program."""
+    capture_init(ctx, num_traces, plot_traces)
+    capture_loop(capture_aes(ctx.obj.ot, ctx.obj.ktp), ctx.obj.cfg["capture"])
+    capture_end(ctx.obj.cfg)
+
+
+def capture_kmac(ot, ktp):
+    """A generator for capturing KMAC traces.
+
+    Args:
+      ot: Initialized OpenTitan target.
+      ktp: Key and plaintext generator.
+    """
+    key, _ = ktp.next()
+    tqdm.write(f'Using key: {binascii.b2a_hex(bytes(key))}')
+    ot.target.simpleserial_write('k', key)
+    while True:
+        _, text = ktp.next()
+        # We don't use `cw.capture_trace()` because we don't expect a response.
+        with cw.common.utils.util.DelayedKeyboardInterrupt():
+            ot.scope.arm()
+            ot.target.simpleserial_write('p', text)
+            timedout = ot.scope.capture()
+            wave = ot.scope.get_last_trace()
+        if timedout or len(wave) == 0:
+            raise RuntimeError('Capture failed.')
+        yield cw.common.traces.Trace(wave, text, None, key)
+
+
+@app_capture.command()
+def sha3(ctx: typer.Context,
+         num_traces: int = opt_num_traces,
+         plot_traces: int = opt_plot_traces):
+    """Capture KMAC traces from a target that runs the `sha3_serial` program."""
+    capture_init(ctx, num_traces, plot_traces)
+    capture_loop(capture_kmac(ctx.obj.ot, ctx.obj.ktp), ctx.obj.cfg["capture"])
+    capture_end(ctx.obj.cfg)
+
+
+@app.command("plot")
+def plot_cmd(ctx: typer.Context, num_traces: int = opt_plot_traces):
+    """Plots previously captured traces."""
+
+    if num_traces is not None:
+        ctx.obj.cfg["plot_capture"]["num_traces"] = num_traces
+    plot_results(ctx.obj.cfg["plot_capture"], ctx.obj.cfg["capture"]["project_name"])
+
+
+@app.callback()
+def main(ctx: typer.Context, cfg_file: str = None):
+    """Capture traces for side-channel analysis."""
+
+    cfg_file = 'capture_aes.yaml' if cfg_file is None else cfg_file
+    with open(cfg_file) as f:
+        cfg = yaml.load(f, Loader=yaml.FullLoader)
+
+    # Store config in the user data attribute (`obj`) of the context.
+    ctx.obj = SimpleNamespace(cfg=cfg)
 
 
 if __name__ == "__main__":
-    args = parse_args()
-
-    with open('capture_aes.yaml') as f:
-        cfg_file = yaml.load(f, Loader=yaml.FullLoader)
-
-    if args.num_traces:
-        cfg_file['capture']['num_traces'] = args.num_traces
-
-    if args.plot_traces:
-        cfg_file['plot_capture']['show'] = True
-        cfg_file['plot_capture']['num_traces'] = args.plot_traces
-
-    ot = initialize_capture(cfg_file['device'], cfg_file['capture'])
-
-    # Key and plaintext generator
-    ktp = cw.ktp.Basic()
-    ktp.key_len = cfg_file['capture']['key_len_bytes']
-    ktp.text_len = cfg_file['capture']['plain_text_len_bytes']
-
-    run_capture(cfg_file['capture'], ot, ktp)
-
-    project_name = cfg_file['capture']['project_name']
-    plot_results(cfg_file['plot_capture'], project_name)
+    app()

--- a/cw/cw305/simple_capture_traces.py
+++ b/cw/cw305/simple_capture_traces.py
@@ -116,7 +116,7 @@ def parse_args():
 if __name__ == "__main__":
     args = parse_args()
 
-    with open('capture.yaml') as f:
+    with open('capture_aes.yaml') as f:
         cfg_file = yaml.load(f, Loader=yaml.FullLoader)
 
     if args.num_traces:

--- a/cw/cw305/simple_capture_traces_batch.py
+++ b/cw/cw305/simple_capture_traces_batch.py
@@ -148,7 +148,7 @@ def parse_args():
 def main():
     """Loads the configuration file, parses command-line arguments, captures and plots traces."""
     args = parse_args()
-    with open("capture.yaml") as f:
+    with open("capture_aes.yaml") as f:
         cfg = yaml.safe_load(f)
     ot = simple_capture.initialize_capture(cfg["device"], cfg["capture"])
     # Seed the PRNG.

--- a/cw/cw305/simple_capture_traces_batch.py
+++ b/cw/cw305/simple_capture_traces_batch.py
@@ -159,7 +159,6 @@ def main():
     ktp = cw.ktp.Basic()
     ktp.key_len = cfg["capture"]["key_len_bytes"]
     ktp.text_len = cfg["capture"]["plain_text_len_bytes"]
-    ot.target.output_len = cfg["capture"]["plain_text_len_bytes"]
     # Init scope
     # TODO: Define a proper interface and cleanup this part.
     scope = SCOPE_FACTORY[args.scope](ot, cfg["capture"])

--- a/cw/cw305/util/device.py
+++ b/cw/cw305/util/device.py
@@ -41,7 +41,7 @@ class RuntimePatchFPGAProgram:
 
 class OpenTitan(object):
     def __init__(self, bitstream, firmware, pll_frequency, baudrate, scope_gain,
-                 num_samples):
+                 num_samples, output_len):
 
         # Extract target board type from bitstream name.
         m = re.search('cw305|cw310', bitstream)
@@ -58,7 +58,7 @@ class OpenTitan(object):
 
         self.fpga = self.initialize_fpga(fpga, bitstream, pll_frequency)
         self.scope = self.initialize_scope(scope_gain, num_samples)
-        self.target = self.initialize_target(self.scope, fw_programmer, baudrate)
+        self.target = self.initialize_target(fw_programmer, baudrate, output_len)
 
     def initialize_fpga(self, fpga, bitstream, pll_frequency):
         """Initializes FPGA bitstream and sets PLL frequency."""
@@ -128,12 +128,12 @@ class OpenTitan(object):
         assert (scope.clock.adc_locked), "ADC failed to lock"
         return scope
 
-    def initialize_target(self, scope, fw_programmer, baudrate):
+    def initialize_target(self, fw_programmer, baudrate, output_len):
         """Loads firmware image and initializes test target."""
         fw_programmer.run(self.fpga)
         time.sleep(0.5)
-        target = cw.target(scope)
-        target.output_len = 16
+        target = cw.target(self.scope)
+        target.output_len = output_len
         target.baud = baudrate
         target.flush()
         return target

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -15,6 +15,7 @@ ray
 scared
 tqdm
 trsfile
+typer
 # can be removed after switching to ray
 joblib
 


### PR DESCRIPTION
This PR adds initial support for capturing sha3/kmac traces and adds `capture aes,` `capture sha3`, `init`, and `plot` commands to the CLI using the `typer` library. This change also refactors device initialization a bit by moving fpga and programmer selection to `device.py` and adds CW310 binaries from lowRISC/opentitan@b1188ef.

This PR includes the following commits:
* Move fpga and programmer selection to device.py
* Add CW310 bitstream and binaries from lowRISC/opentitan@b1188ef
* Use separate config files for aes and sha3 (please don't forget to use `--cfg-file capture_sha3.yaml` for sha3)
* Move output_len to OpenTitan() init
* Add SHA3/KMAC capture support using Typer

I verified that aes capture works on both boards and sha3 capture works on CW310 but I would appreciate it if you could try this change on your setup and let me know if you run into any issues.

Command line help messages:
```
$ ./simple_capture_traces.py --help
Usage: simple_capture_traces.py [OPTIONS] COMMAND [ARGS]...

  Capture traces for side-channel analysis.

Options:
  --cfg-file TEXT
  --help           Show this message and exit.

Commands:
  capture  Capture traces for SCA
  init     Initalize target for SCA.
  plot     Plots previously captured traces.
```

```
$ ./simple_capture_traces.py capture --help
Usage: simple_capture_traces.py capture [OPTIONS] COMMAND [ARGS]...

  Capture traces for SCA

Options:
  --help  Show this message and exit.

Commands:
  aes   Capture AES traces from a target that runs the `aes_serial` program.
  sha3  Capture KMAC traces from a target that runs the `sha3_serial`...
```

```
$ ./simple_capture_traces.py capture aes --help
Usage: simple_capture_traces.py capture aes [OPTIONS]

  Capture AES traces from a target that runs the `aes_serial` program.

Options:
  --num-traces INTEGER   Number of traces to capture.
  --plot-traces INTEGER  Number of traces to plot.
  --help                 Show this message and exit.
```