### PR TITLE
Pin chipwhisperer version in the requirements file

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -20,4 +20,4 @@ joblib
 
 # The development version of the ChipWhisperer toolchain with latest features
 # and bug fixes needs to be installed in editable mode.
--e git+https://github.com/newaetech/chipwhisperer.git#egg=chipwhisperer
+-e git+https://github.com/newaetech/chipwhisperer.git@099807207f3351d16e7988d8f0cccf6d570f306a#egg=chipwhisperer


### PR DESCRIPTION
Currently, we get the latest chipwhisperer version whenever we `pip install`. This change adds a commit hash for chipwhisperer to the requirements file to give us more control over updating chipwhisperer versions.

@vogelpi and I spent a quite bit of time today to recover from an upstream change that breaks segmented captures using cw-lite on our setup. We were able to identify the following working combination:
* Chipwhisperer commit: newaetech/chipwhisperer@099807207f3351d16e7988d8f0cccf6d570f306a
* Chipwhisperer-lite firmware version: 0.23 (probably added in newaetech/chipwhisperer@f904ad556b692ea22ec54f1bde8628c7e31a0944 or the commit before that) This is older than the firmware in the chipwhisperer repo but we can identify a more recent working version later and update the hash in the requirements file later.

Signed-off-by: Alphan Ulusoy <alphan@google.com>