### PR TITLE
[ceca] Report number of correctly guessed key byte differences

### DIFF
--- a/cw/cw305/ceca.py
+++ b/cw/cw305/ceca.py
@@ -82,7 +82,6 @@ class TraceWorker:
         """
         self.project = cw.open_project(project_file)
         # TODO: Consider more efficient formats.
-        trace_cnt = trace_slice.stop - trace_slice.start
         self.num_samples = attack_window.stop - attack_window.start
         if attack_direction == AttackDirection.INPUT:
             self.texts = np.vstack(self.project.textins[trace_slice])
@@ -504,7 +503,7 @@ def perform_attack(
     if key is not None:
         logging.info(f"Recovered AES key: {bytes(key).hex()}")
     else:
-        logging.error(f"Failed to recover the AES key")
+        logging.error("Failed to recover the AES key")
     return key
 
 


### PR DESCRIPTION
This number is a actually a far more relevant indicator for the amount of leakage in the traces than successful key recovery (pass/fail). Therefore, this PR adds the functionality to compute this number and report it on the command line.

This solves #30 .