### PR TITLE
SHA3 capture improvements

### DIFF
--- a/cw/cw305/capture_aes.yaml
+++ b/cw/cw305/capture_aes.yaml
@@ -7,6 +7,7 @@ capture:
   # Only AES-128 ECB is supported at this moment.
   key_len_bytes: 16
   plain_text_len_bytes: 16
+  output_len_bytes: 16
   # Samples per trace - We oversample by 10x and AES with DOM is doing
   # ~56/72 cycles per encryption (AES-128/256).
   num_samples: 740

--- a/cw/cw305/capture_sha3.yaml
+++ b/cw/cw305/capture_sha3.yaml
@@ -7,7 +7,7 @@ capture:
   key_len_bytes: 16
   plain_text_len_bytes: 16
   num_samples: 8000
-  scope_gain: 23
+  scope_gain: 30
   num_traces: 100
   project_name: projects/opentitan_simple_sha3
   waverunner_ip: 192.168.1.228

--- a/cw/cw305/capture_sha3.yaml
+++ b/cw/cw305/capture_sha3.yaml
@@ -7,7 +7,7 @@ capture:
   key_len_bytes: 16
   plain_text_len_bytes: 16
   output_len_bytes: 32
-  num_samples: 8000
+  num_samples: 2000
   scope_gain: 30
   num_traces: 100
   project_name: projects/opentitan_simple_sha3

--- a/cw/cw305/capture_sha3.yaml
+++ b/cw/cw305/capture_sha3.yaml
@@ -6,6 +6,7 @@ device:
 capture:
   key_len_bytes: 16
   plain_text_len_bytes: 16
+  output_len_bytes: 32
   num_samples: 8000
   scope_gain: 30
   num_traces: 100

--- a/cw/cw305/objs/aes_serial_fpga_cw310.bin
+++ b/cw/cw305/objs/aes_serial_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ce46b1a6720729dc77382b9593095f4eb62d59e9dad70111cee453b3cd05484
-size 10280
+oid sha256:a93f12ac01c69ed0f78c69332ec52732c412c57eb9bc224ad309bffd7ff044b3
+size 10288

--- a/cw/cw305/objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit
+++ b/cw/cw305/objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0166f1afdb206fc368061abf3099c23f03683720b1f01c19567c09d32baae105
+oid sha256:dbc8399ea2b40f2e3fc2433379e9cd1154315ffb4bf951b1ccf7613f09982bfc
 size 15878032

--- a/cw/cw305/objs/sha3_serial_fpga_cw310.bin
+++ b/cw/cw305/objs/sha3_serial_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aca3e1d441466078fc77e1f70698b8bb66d8a911a5acc2f6a2fffaa143691951
-size 9632
+oid sha256:bcf6974151dcf7e7c320869233b1f00d1b3b969df33ce3c2ba334d392014785b
+size 9696

--- a/cw/cw305/simple_capture_traces.py
+++ b/cw/cw305/simple_capture_traces.py
@@ -36,7 +36,7 @@ def initialize_capture(device_cfg, capture_cfg):
                           device_cfg["baudrate"],
                           capture_cfg["scope_gain"],
                           capture_cfg["num_samples"],
-                          capture_cfg["plain_text_len_bytes"])
+                          capture_cfg["output_len_bytes"])
     print(f'Scope setup with sampling rate {ot.scope.clock.adc_rate} S/s')
     # Ping target
     print('Reading from FPGA using simpleserial protocol.')


### PR DESCRIPTION
This PR contains the following improvements to the SHA3 capture:
- Adjust the scope gain
- Verify SHA3 operation using pyXKCP on the host
- Update CW310 binaries for optimized SHA3 captures (less noise, less samples etc.)

I will rebase this once the corresponding OpenTitan PR lowRISC/OpenTitan#8240 has been merged. 