### PR TITLE
Update binaries to lowRISC/OpenTitan@862155839

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
+cw/cw305/objs/lowrisc_systems_chip_englishbreakfast_cw305_0.1.bit filter=lfs diff=lfs merge=lfs -text
 cw/cw305/objs/aes_serial_fpga_nexysvideo.bin filter=lfs diff=lfs merge=lfs -text
-cw/cw305/objs/lowrisc_systems_top_englishbreakfast_cw305_0.1.bit filter=lfs diff=lfs merge=lfs -text
 cw/cw305/objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit filter=lfs diff=lfs merge=lfs -text
 cw/cw305/objs/sha3_serial_fpga_cw310.bin filter=lfs diff=lfs merge=lfs -text
 cw/cw305/objs/aes_serial_fpga_cw310.bin filter=lfs diff=lfs merge=lfs -text

--- a/cw/cw305/objs/aes_serial_fpga_cw310.bin
+++ b/cw/cw305/objs/aes_serial_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a93f12ac01c69ed0f78c69332ec52732c412c57eb9bc224ad309bffd7ff044b3
-size 10288
+oid sha256:ac543490274d099e30555c58960b6ec282a8965f4c2a8a4cb29a1dab6ba5eead
+size 11476

--- a/cw/cw305/objs/aes_serial_fpga_nexysvideo.bin
+++ b/cw/cw305/objs/aes_serial_fpga_nexysvideo.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28f6774d63c76756330ea3a4dad6348dd05a6ffa239bbb7bc93a8320a9b21d6d
-size 10744
+oid sha256:91f9e4c0e8c76f589a6cd45995b42e43ae5d4176dd3a79def61c93c1f3823bfc
+size 10740

--- a/cw/cw305/objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit
+++ b/cw/cw305/objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dbc8399ea2b40f2e3fc2433379e9cd1154315ffb4bf951b1ccf7613f09982bfc
+oid sha256:433a7db9495f2ce084820758989cfb18d7b3dfcfde2717fd397fa362c7517e6d
 size 15878032

--- a/cw/cw305/objs/lowrisc_systems_chip_englishbreakfast_cw305_0.1.bit
+++ b/cw/cw305/objs/lowrisc_systems_chip_englishbreakfast_cw305_0.1.bit
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24a1092d2228c1ffd7102e47e880bbb6113a879e3634fcfe9f47662c70636dc4
+size 3825912

--- a/cw/cw305/objs/lowrisc_systems_top_englishbreakfast_cw305_0.1.bit
+++ b/cw/cw305/objs/lowrisc_systems_top_englishbreakfast_cw305_0.1.bit
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:548bd1fb0530c1843644c0bba6856061c0f23cf77847542f94a1bad46d0273ad
-size 3825913

--- a/cw/cw305/objs/sha3_serial_fpga_cw310.bin
+++ b/cw/cw305/objs/sha3_serial_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bcf6974151dcf7e7c320869233b1f00d1b3b969df33ce3c2ba334d392014785b
-size 9696
+oid sha256:6cf2ac9f5e8849b3f04eafee2c59dff5ed96eea3a6560e99e30e53e6c2539961
+size 10844

--- a/cw/cw305/vendor/lowrisc_opentitan.lock.hjson
+++ b/cw/cw305/vendor/lowrisc_opentitan.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/opentitan
-    rev: ae4b39564d092ed0393bab561f2b77441735244e
+    rev: 369cffc85db0e6d5a667676a6f89987b94210e70
   }
 }

--- a/cw/cw305/vendor/lowrisc_opentitan/cw_spiflash.py
+++ b/cw/cw305/vendor/lowrisc_opentitan/cw_spiflash.py
@@ -83,11 +83,14 @@ class _SpiFlashFrame:
         padding = self.PAYLOAD_SIZE - len(self._payload)
         if padding > 0:
             self._payload = b''.join([self._payload, b'\xFF' * padding])
+
+        # Reverse the order of the bytes to make them little-endian and be
+        # consistent with the code signing tool.
         self._digest = self.HASH_FUNCTION(b''.join([
             self._frame_number,
             self._flash_offset,
             self._payload,
-        ])).digest()
+        ])).digest()[::-1]
 
     def __bytes__(self):
         return b''.join([
@@ -109,7 +112,9 @@ class _SpiFlashFrame:
     @property
     def expected_ack(self):
         """Expected acknowledgement value for the frame."""
-        return self.HASH_FUNCTION(bytes(self)).digest()
+        # Reverse the order of the bytes to make them little-endian and be
+        # consistent with the code signing tool.
+        return self.HASH_FUNCTION(bytes(self)).digest()[::-1]
 
 
 class _Bootstrap:


### PR DESCRIPTION
This PR updates all binaries to a more recent version of the OpenTitan repository. All binaries are taken from lowRISC/OpenTitan@862155839 except for the CW305 bitstream for which also lowRISC/OpenTitan@b8f24c491 has been cherry picked to reduce the FPGA resource utilization.

The reason for doing this is that there have been major updates to the hardware IPs and the software, as well as SPI that are incompatible with the previous binaries included in this repo. This complicates experiments with newer bitstreams or modified application binaries.

Signed-off-by: Pirmin Vogel <vogelpi@lowrisc.org>

Update lowrisc_opentitan to lowRISC/opentitan@369cffc85

Update code from upstream repository https://github.com/lowRISC/opentitan to revision 
369cffc85db0e6d5a667676a6f89987b94210e70

* [util,sw] Reverse bootstrap hash word order (Miguel Osorio)

Signed-off-by: Pirmin Vogel <vogelpi@lowrisc.org>