### PR TITLE
Documentation and dependency fixes

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -63,7 +63,7 @@ machine or obtained using the provided [Dockerfile](https://github.com/lowRISC/o
 
 This repository has a couple of Python dependencies. You can run
 ```console
-$ pip install --user -r python_requirements.txt
+$ pip install --user -r python-requirements.txt
 ```
 to install those dependencies.
 

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -78,9 +78,10 @@ However, it has some non-Python dependencies related to USB. Please see
 to install the specific `apt` packages required by ChipWhisperer.
 
 **Notes:**
-- Python 3.6.9 is **okay** for ChipWhisperer - it may force you to use
-  Python 3.7 due to requirements enforced by the latest version of NumPy. This
-  is however not a hard requirement.
+- We recommend to use Python 3.7. Previously, Python 3.6.9 was okay, but newer
+  patches releases of Python 3.6 might fail dependency resolution. Python 3.8
+  might work as well, but in Python 3.9 and later, the `ray` dependency is
+  currently not available.
 - CW-Husky requires ChipWhisperer 5.6.1 or later. The default
   `python_requirements.txt` will install a version supporting CW-Husky.
 - CW-Lite requires the following specifc commit of ChipWhisperer and firmware

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -21,6 +21,8 @@ typer
 # can be removed after switching to ray
 joblib
 
-# The development version of the ChipWhisperer toolchain with latest features
-# and bug fixes needs to be installed in editable mode.
--e git+https://github.com/newaetech/chipwhisperer.git#egg=chipwhisperer
+# Development version of ChipWhisperer toolchain - Fix the version for now
+# Prefer the archive download over a git clone to decrease installation time
+# (The chipwhisperer repository is rather large and uses additionally uses
+# submodules, which need to be fetched as well.)
+https://github.com/newaetech/chipwhisperer/archive/5f44556d30d791f4847e8f37ae9c1dce764dbe73.tar.gz


### PR DESCRIPTION
This PR:
- Clarifies that Python 3.7 or later should be used.
- Fixes a typo in the doc.
- Fixes the ChipWhisperer version to something known good and installs the archive rather than using git checkout in editable mode (may lead to issues with the main OpenTitan install where we can't upgrade the ChipWhisperer toolchain anymore due to the Python 3.6.5 requirement of OT). 