### PR TITLE
[sca] Add AES General Test: FvsR Key.

### DIFF
--- a/cw/cw305/simple_capture_traces.py
+++ b/cw/cw305/simple_capture_traces.py
@@ -123,8 +123,9 @@ def capture_end(cfg):
         plot_results(cfg["plot_capture"], cfg["capture"]["project_name"])
 
 
-def capture_aes(ot, ktp):
+def capture_aes_random(ot, ktp):
     """A generator for capturing AES traces.
+    Fixed key, Random texts.
 
     Args:
       ot: Initialized OpenTitan target.
@@ -145,18 +146,77 @@ def capture_aes(ot, ktp):
         yield ret
 
 
+def capture_aes_fvsr_key(ot):
+    """A generator for capturing AES traces for fixed vs random key test.
+    The data collection method is based on the derived test requirements (DTR) for TVLA:
+    https://www.rambus.com/wp-content/uploads/2015/08/TVLA-DTR-with-AES.pdf
+    The measurements are taken by using either fixed or randomly selected key.
+    In order to simplify the analysis, the first sample has to use fixed key.
+    The initial key and plaintext values as well as the derivation methods are as specified in the
+    DTR.
+
+    Args:
+      ot: Initialized OpenTitan target.
+    """
+    key_generation = bytearray([0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF1,
+                                0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xE0, 0xF0])
+    cipher_gen = AES.new(bytes(key_generation), AES.MODE_ECB)
+    text_fixed = bytearray([0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+                            0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA])
+    text_random = bytearray([0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC,
+                             0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC])
+    key_fixed = bytearray([0x81, 0x1E, 0x37, 0x31, 0xB0, 0x12, 0x0A, 0x78,
+                           0x42, 0x78, 0x1E, 0x22, 0xB2, 0x5C, 0xDD, 0xF9])
+    key_random = bytearray([0x53, 0x53, 0x53, 0x53, 0x53, 0x53, 0x53, 0x53,
+                            0x53, 0x53, 0x53, 0x53, 0x53, 0x53, 0x53, 0x53])
+
+    tqdm.write(f'Fixed key: {binascii.b2a_hex(bytes(key_fixed))}')
+
+    sample_fixed = 1
+    while True:
+        if sample_fixed:
+            text_fixed = bytearray(cipher_gen.encrypt(text_fixed))
+            key, text = key_fixed, text_fixed
+        else:
+            text_random = bytearray(cipher_gen.encrypt(text_random))
+            key_random = bytearray(cipher_gen.encrypt(key_random))
+            key, text = key_random, text_random
+        sample_fixed = random.randint(0, 1)
+
+        cipher = AES.new(bytes(key), AES.MODE_ECB)
+        ret = cw.capture_trace(ot.scope, ot.target, text, key, ack=False)
+        if not ret:
+            raise RuntimeError('Capture failed.')
+        expected = binascii.b2a_hex(cipher.encrypt(bytes(text)))
+        got = binascii.b2a_hex(ret.textout)
+        if got != expected:
+            raise RuntimeError(f'Bad ciphertext: {got} != {expected}.')
+        yield ret
+
+
 @app_capture.command()
-def aes(ctx: typer.Context,
+def aes_random(ctx: typer.Context,
         num_traces: int = opt_num_traces,
         plot_traces: int = opt_plot_traces):
     """Capture AES traces from a target that runs the `aes_serial` program."""
     capture_init(ctx, num_traces, plot_traces)
-    capture_loop(capture_aes(ctx.obj.ot, ctx.obj.ktp), ctx.obj.cfg["capture"])
+    capture_loop(capture_aes_random(ctx.obj.ot, ctx.obj.ktp), ctx.obj.cfg["capture"])
     capture_end(ctx.obj.cfg)
 
 
-def capture_kmac(ot, ktp):
-    """A generator for capturing KMAC traces.
+@app_capture.command()
+def aes_fvsr_key(ctx: typer.Context,
+        num_traces: int = opt_num_traces,
+        plot_traces: int = opt_plot_traces):
+    """Capture AES traces from a target that runs the `aes_serial` program."""
+    capture_init(ctx, num_traces, plot_traces)
+    capture_loop(capture_aes_fvsr_key(ctx.obj.ot), ctx.obj.cfg["capture"])
+    capture_end(ctx.obj.cfg)
+
+
+def capture_sha3_random(ot, ktp):
+    """A generator for capturing SHA3 (KMAC) traces.
+    Fixed key, Random texts.
 
     Args:
       ot: Initialized OpenTitan target.
@@ -180,9 +240,9 @@ def capture_kmac(ot, ktp):
         yield ret
 
 
-def capture_kmac_key(ot):
-    """A generator for capturing KMAC traces.
-    The date -collection method is based on the derived test requirements (DTR) for TVLA:
+def capture_sha3_fvsr_key(ot):
+    """A generator for capturing SHA3 (KMAC) traces.
+    The data collection method is based on the derived test requirements (DTR) for TVLA:
     https://www.rambus.com/wp-content/uploads/2015/08/TVLA-DTR-with-AES.pdf
     The measurements are taken by using either fixed or randomly selected key.
     In order to simplify the analysis, the first sample has to use fixed key.
@@ -193,8 +253,8 @@ def capture_kmac_key(ot):
       ot: Initialized OpenTitan target.
     """
 
-    key_generation = bytearray([0x81, 0x1E, 0x37, 0x31, 0xB0, 0x12, 0x0A, 0x78,
-                                0x42, 0x78, 0x1E, 0x22, 0xB2, 0x5C, 0xDD, 0xF9])
+    key_generation = bytearray([0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF1,
+                                0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xE0, 0xF0])
     cipher = AES.new(bytes(key_generation), AES.MODE_ECB)
     text_fixed = bytearray([0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
                             0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA])
@@ -241,13 +301,22 @@ def capture_kmac_key(ot):
 
 
 @app_capture.command()
-def sha3(ctx: typer.Context,
+def sha3_random(ctx: typer.Context,
          num_traces: int = opt_num_traces,
          plot_traces: int = opt_plot_traces):
-    """Capture KMAC traces from a target that runs the `sha3_serial` program."""
+    """Capture SHA3 (KMAC) traces from a target that runs the `sha3_serial` program."""
     capture_init(ctx, num_traces, plot_traces)
-    # capture_loop(capture_kmac_key(ctx.obj.ot, ctx.obj.ktp), ctx.obj.cfg["capture"])
-    capture_loop(capture_kmac_key(ctx.obj.ot), ctx.obj.cfg["capture"])
+    capture_loop(capture_sha3_random(ctx.obj.ot, ctx.obj.ktp), ctx.obj.cfg["capture"])
+    capture_end(ctx.obj.cfg)
+
+
+@app_capture.command()
+def sha3_fvsr_key(ctx: typer.Context,
+         num_traces: int = opt_num_traces,
+         plot_traces: int = opt_plot_traces):
+    """Capture SHA3 (KMAC) traces from a target that runs the `sha3_serial` program."""
+    capture_init(ctx, num_traces, plot_traces)
+    capture_loop(capture_sha3_fvsr_key(ctx.obj.ot), ctx.obj.cfg["capture"])
     capture_end(ctx.obj.cfg)
 
 

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -411,7 +411,7 @@ The main configuration of the OpenTitan SCA setup is stored in the files
 cw/cw305/capture_aes.yaml
 cw/cw305/capture_sha3.yaml
 ```
-for AES and KMAC, respectively.
+for AES and SHA3 (KMAC), respectively.
 
 For example, these files allow to specify the FPGA bitstream to be loaded, the
 OpenTitan application binary to execute, the default number of traces to
@@ -435,7 +435,7 @@ the specified file paths.
 There are currently two different scripts available for capturing OpenTitan
 power traces:
 
-* `simple_capture_traces.py`: Supports capturing AES and KMAC power traces
+* `simple_capture_traces.py`: Supports capturing AES and SHA3 (KMAC) power traces
   using either a CW-Husky or CW-Lite capture board.
 
 * `simple_capture_traces_batch.py`: Supports capturing AES power traces
@@ -451,12 +451,13 @@ a capture with fewer traces to make sure the setup is configured as expected
 To perform a non-batched AES capture, you can use the following command:
 ```console
 $ cd cw/cw305
-$ ./simple_capture_traces.py --cfg-file capture_aes.yaml capture aes --num-traces 100 --plot-traces 10
+$ ./simple_capture_traces.py --cfg-file capture_aes.yaml capture aes-random --num-traces 100 --plot-traces 10
 ```
 This script will load the OpenTitan FPGA bitstream to the target board, load
 and start the application binary to the target via SPI, and then feed data in
-and out of the target while capturing power traces on the capture board. It
-should produce console output similar to the following output:
+and out of the target while capturing power traces on the capture board. It 
+will send AES requests with a fixed key and random texts. It should produce 
+console output similar to the following output:
 
 ```console
 Connecting and loading FPGA... Done!
@@ -475,6 +476,13 @@ Target simpleserial version: z01 (attempts: 2).
 Using key: b'2b7e151628aed2a6abf7158809cf4f3c'                                  
 Capturing: 100%|██████████████████████████████| 100/100 [00:01<00:00, 50.04it/s]
 Created plot with 10 traces: ~/ot-sca/cw/cw305/projects/sample_traces_aes.html
+```
+
+Following command may be used to capture traces for DTR TVLA Section 5.3: 
+"General Test: Fixed-vs.-Random Key Datasets":
+```console
+$ cd cw/cw305
+$ ./simple_capture_traces.py --cfg-file capture_aes.yaml capture aes-fvsr-key --num-traces 100 --plot-traces 10
 ```
 
 In case you see console output like
@@ -499,13 +507,22 @@ in the `.yaml` configuration file. Note that boards have some natural
 variation, and changes such as the clock frequency, core voltage, and device
 utilization (FPGA build) will all affect the safe maximum gain setting.
 
-### KMAC Capture
+### SHA3 (KMAC) Capture
 
-To perform a KMAC capture, use this command:
+To perform a SHA3 (KMAC) capture, use this command:
 ```console
 $ cd cw/cw305
-$ ./simple_capture_traces.py --cfg-file capture_sha3.yaml capture sha3 --num-traces 100 --plot-traces 10
+$ ./simple_capture_traces.py --cfg-file capture_sha3.yaml capture sha3-random --num-traces 100 --plot-traces 10
 ```
+
+The above command will send SHA3 (KMAC) requests with a fixed key and random 
+texts. In order to capture traces for DTR TVLA Section 5.3: "General Test: 
+Fixed-vs.-Random Key Datasets", following command may be used:
+```console
+$ cd cw/cw305
+$ ./simple_capture_traces.py --cfg-file capture_sha3.yaml capture sha3-fvsr-key --num-traces 100 --plot-traces 10
+```
+
 
 You should see similar output as in the AES example. Once the power traces have
 been collected, a picture similar to the following should be shown in your


### PR DESCRIPTION
The data collection method is based on the derived test requirements
(DTR) for TVLA: https://www.rambus.com/wp-content/uploads/2015/08/TVLA-
DTR-with-AES.pdf section 5.3. Two datasets: fixed key and varying key.
Text is always varying for both datasets. Code snippet tested on CW Husky
Board and CW310 target.

Signed-off-by: Abdullah Varici <abdullah.varici@lowrisc.org>