### PR TITLE
Optimize SCA trace capture

### DIFF
--- a/cw/cw305/capture_aes.yaml
+++ b/cw/cw305/capture_aes.yaml
@@ -8,9 +8,9 @@ capture:
   key_len_bytes: 16
   plain_text_len_bytes: 16
   output_len_bytes: 16
-  # Samples per trace - We oversample by 10x and AES with DOM is doing
+  # Samples per trace - We oversample by 20x and AES w/ DOM is doing
   # ~56/72 cycles per encryption (AES-128/256).
-  num_samples: 740
+  num_samples: 1200
   scope_gain: 32.5
   num_traces: 5000
   project_name: projects/opentitan_simple_aes

--- a/cw/cw305/capture_aes.yaml
+++ b/cw/cw305/capture_aes.yaml
@@ -11,6 +11,10 @@ capture:
   # Samples per trace - We oversample by 20x and AES w/ DOM is doing
   # ~56/72 cycles per encryption (AES-128/256).
   num_samples: 1200
+  # Offest in samples - The AES idle signal becomes visible 1 target clock
+  # cycle later (20 samples) and there are 2 synchronization stages at 100 MHz
+  # at the top level (4 samples).
+  offset: -40
   scope_gain: 32.5
   num_traces: 5000
   project_name: projects/opentitan_simple_aes

--- a/cw/cw305/capture_sha3.yaml
+++ b/cw/cw305/capture_sha3.yaml
@@ -7,7 +7,7 @@ capture:
   key_len_bytes: 16
   plain_text_len_bytes: 16
   output_len_bytes: 32
-  num_samples: 2000
+  num_samples: 4000
   scope_gain: 30
   num_traces: 100
   project_name: projects/opentitan_simple_sha3

--- a/cw/cw305/capture_sha3.yaml
+++ b/cw/cw305/capture_sha3.yaml
@@ -7,7 +7,20 @@ capture:
   key_len_bytes: 16
   plain_text_len_bytes: 16
   output_len_bytes: 32
-  num_samples: 4000
+  # Samples per trace - We oversample by 20x and KMAC is doing 24 or 96 cycles
+  # for the key absorb w/o or w/ DOM, respectively, as well as 23 cycles for
+  # XORing the key into the state.
+  # w/o DOM
+  num_samples: 1600
+  # w/ DOM
+  #num_samples: 3200
+  # Offest in samples - During the first activity block, KMAC just absorbs the
+  # fixed prefix (23 cycles XORing + 24 or 96 cycles absorbing w/o or w/ DOM,
+  # respectively). This first activity block can be skipped.
+  # w/o DOM
+  offset: 860
+  # w/ DOM
+  #offset: 2300
   scope_gain: 30
   num_traces: 100
   project_name: projects/opentitan_simple_sha3

--- a/cw/cw305/cw_segmented.py
+++ b/cw/cw305/cw_segmented.py
@@ -65,7 +65,7 @@ class CwSegmented:
             this many trigger events. Read-only.
     """
 
-    def __init__(self, num_samples=740, scope_gain=23, scope=None):
+    def __init__(self, num_samples=1200, scope_gain=23, scope=None):
         """Inits a CwSegmented.
 
         Args:
@@ -91,7 +91,10 @@ class CwSegmented:
 
         self._configure_scope(scope_gain)
         self.num_segments = 1
-        self.num_samples = num_samples
+        if self._is_husky:
+            self.num_samples = num_samples
+        else:
+            self.num_samples = num_samples // 2
         self._print_device_info()
 
     @property
@@ -171,12 +174,14 @@ class CwSegmented:
         self._scope.adc.offset = 0
         self._scope.adc.basic_mode = "rising_edge"
         if self._is_husky:
+            # We sample using the target clock * 2 (200 MHz).
+            self._scope.clock.clkgen_freq = 100000000
             self._scope.clock.clkgen_src = 'extclk'
-            self._scope.clock.adc_mul = 1
+            self._scope.clock.adc_mul = 2
         else:
+            # We sample using the target clock (100 MHz).
             self._scope.adc.fifo_fill_mode = "segment"
             self._scope.clock.clkgen_freq = 100000000
-            # We sample using the target clock (100 MHz).
             self._scope.clock.adc_src = "extclk_dir"
 
         self._scope.trigger.triggers = "tio4"

--- a/cw/cw305/simple_capture_traces.py
+++ b/cw/cw305/simple_capture_traces.py
@@ -37,6 +37,7 @@ def initialize_capture(device_cfg, capture_cfg):
                           device_cfg["baudrate"],
                           capture_cfg["scope_gain"],
                           capture_cfg["num_samples"],
+                          capture_cfg["offset"],
                           capture_cfg["output_len_bytes"])
     print(f'Scope setup with sampling rate {ot.scope.clock.adc_freq} S/s')
     # Ping target

--- a/cw/cw305/simple_capture_traces_batch.py
+++ b/cw/cw305/simple_capture_traces_batch.py
@@ -32,7 +32,9 @@ def create_waverunner(ot, capture_cfg):
 
 def create_cw_segmented(ot, capture_cfg):
     return CwSegmented(num_samples=capture_cfg["num_samples"],
-                           scope_gain=capture_cfg["scope_gain"], scope=ot.scope)
+                       offset=capture_cfg["offset"],
+                       scope_gain=capture_cfg["scope_gain"],
+                       scope=ot.scope)
 
 
 SCOPE_FACTORY = {

--- a/cw/cw305/util/device.py
+++ b/cw/cw305/util/device.py
@@ -111,16 +111,19 @@ class OpenTitan(object):
         """Initializes chipwhisperer scope."""
         scope = cw.scope()
         scope.gain.db = scope_gain
-        scope.adc.samples = num_samples
         scope.adc.offset = 0
         scope.adc.basic_mode = "rising_edge"
-        scope.clock.clkgen_freq = 100000000
-        # We sample using the target clock (100 MHz).
         if hasattr(scope, '_is_husky') and scope._is_husky:
+            # We sample using the target clock * 2 (200 MHz).
+            scope.adc.samples = num_samples
+            scope.clock.clkgen_freq = 100000000
             scope.clock.clkgen_src = 'extclk'
-            scope.clock.adc_mul = 1
+            scope.clock.adc_mul = 2
             husky = True
         else:
+            # We sample using the target clock (100 MHz).
+            scope.adc.samples = num_samples // 2
+            scope.clock.clkgen_freq = 100000000
             scope.clock.adc_src = 'extclk_dir'
             husky = False
         scope.trigger.triggers = "tio4"

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -25,4 +25,4 @@ joblib
 # Prefer the archive download over a git clone to decrease installation time
 # (The chipwhisperer repository is rather large and uses additionally uses
 # submodules, which need to be fetched as well.)
-https://github.com/newaetech/chipwhisperer/archive/5f44556d30d791f4847e8f37ae9c1dce764dbe73.tar.gz
+https://github.com/newaetech/chipwhisperer/archive/99abbcad2bfdadee47dded973684a696b64a1c09.tar.gz


### PR DESCRIPTION
This PR contains three commits to optimize the trace capture using ChipWhisperer:
1. The sampling rate is increased to 200 MS/s which is the maximum supported by Husky. CW-Lite keeps collecting traces with 100 MS/s (max supported 105 MS/s) the number of samples to record is adjusted internally for CW-Lite.
2. Allow negative and positive sampling offsets to be defined through the config file. Is allows to better tune the capture window.
3. Tune the capture window for SHA3.

Also, this PR updates the ChipWhisperer version to get a more recent of the library.