### PR TITLE
Use uint16 instead of double for storing the captured waves

### DIFF
--- a/cw/cw305/capture_aes.yaml
+++ b/cw/cw305/capture_aes.yaml
@@ -24,5 +24,3 @@ plot_capture:
   show: true
   num_traces: 50
   trace_image_filename: projects/sample_traces_aes.html
-  # The ADC output is in the interval [-0.5, 0.5). Define safety margin.
-  amplitude_max: 0.48

--- a/cw/cw305/capture_sha3.yaml
+++ b/cw/cw305/capture_sha3.yaml
@@ -30,5 +30,3 @@ plot_capture:
   show: true
   num_traces: 100
   trace_image_filename: projects/sample_traces_sha3.html
-  # The ADC output is in the interval [-0.5, 0.5). Define safety margin.
-  amplitude_max: 0.48

--- a/cw/cw305/cw_segmented.py
+++ b/cw/cw305/cw_segmented.py
@@ -229,6 +229,6 @@ class CwSegmented:
             self._scope.capture()
         else:
             self._scope.capture_segmented()
-        data = self._scope.get_last_trace()
+        data = self._scope.get_last_trace(as_int=True)
         waves = self._parse_waveform(data)
         return waves

--- a/cw/cw305/cw_segmented.py
+++ b/cw/cw305/cw_segmented.py
@@ -182,14 +182,15 @@ class CwSegmented:
         self._scope.adc.basic_mode = "rising_edge"
         if self._is_husky:
             # We sample using the target clock * 2 (200 MHz).
+            self._scope.clock.adc_mul = 2
             self._scope.clock.clkgen_freq = 100000000
             self._scope.clock.clkgen_src = 'extclk'
-            self._scope.clock.adc_mul = 2
         else:
             # We sample using the target clock (100 MHz).
-            self._scope.adc.fifo_fill_mode = "segment"
+            self._scope.clock.adc_mul = 1
             self._scope.clock.clkgen_freq = 100000000
             self._scope.clock.adc_src = "extclk_dir"
+            self._scope.adc.fifo_fill_mode = "segment"
 
         self._scope.trigger.triggers = "tio4"
         self._scope.io.tio1 = "serial_tx"

--- a/cw/cw305/simple_capture_traces.py
+++ b/cw/cw305/simple_capture_traces.py
@@ -202,8 +202,8 @@ def capture_aes_fvsr_key(ot):
 
 @app_capture.command()
 def aes_random(ctx: typer.Context,
-        num_traces: int = opt_num_traces,
-        plot_traces: int = opt_plot_traces):
+               num_traces: int = opt_num_traces,
+               plot_traces: int = opt_plot_traces):
     """Capture AES traces from a target that runs the `aes_serial` program."""
     capture_init(ctx, num_traces, plot_traces)
     capture_loop(capture_aes_random(ctx.obj.ot, ctx.obj.ktp), ctx.obj.ot, ctx.obj.cfg["capture"])
@@ -212,8 +212,8 @@ def aes_random(ctx: typer.Context,
 
 @app_capture.command()
 def aes_fvsr_key(ctx: typer.Context,
-        num_traces: int = opt_num_traces,
-        plot_traces: int = opt_plot_traces):
+                 num_traces: int = opt_num_traces,
+                 plot_traces: int = opt_plot_traces):
     """Capture AES traces from a target that runs the `aes_serial` program."""
     capture_init(ctx, num_traces, plot_traces)
     capture_loop(capture_aes_fvsr_key(ctx.obj.ot), ctx.obj.ot, ctx.obj.cfg["capture"])
@@ -310,8 +310,8 @@ def capture_sha3_fvsr_key(ot):
 
 @app_capture.command()
 def sha3_random(ctx: typer.Context,
-         num_traces: int = opt_num_traces,
-         plot_traces: int = opt_plot_traces):
+                num_traces: int = opt_num_traces,
+                plot_traces: int = opt_plot_traces):
     """Capture SHA3 (KMAC) traces from a target that runs the `sha3_serial` program."""
     capture_init(ctx, num_traces, plot_traces)
     capture_loop(capture_sha3_random(ctx.obj.ot, ctx.obj.ktp), ctx.obj.ot, ctx.obj.cfg["capture"])
@@ -320,8 +320,8 @@ def sha3_random(ctx: typer.Context,
 
 @app_capture.command()
 def sha3_fvsr_key(ctx: typer.Context,
-         num_traces: int = opt_num_traces,
-         plot_traces: int = opt_plot_traces):
+                  num_traces: int = opt_num_traces,
+                  plot_traces: int = opt_plot_traces):
     """Capture SHA3 (KMAC) traces from a target that runs the `sha3_serial` program."""
     capture_init(ctx, num_traces, plot_traces)
     capture_loop(capture_sha3_fvsr_key(ctx.obj.ot), ctx.obj.ot, ctx.obj.cfg["capture"])

--- a/cw/cw305/simple_capture_traces_batch.py
+++ b/cw/cw305/simple_capture_traces_batch.py
@@ -116,7 +116,8 @@ def run_batch_capture(capture_cfg, ot, ktp, scope):
             # Add traces of this batch to the project.
             for wave, plaintext, ciphertext in zip(waves, plaintexts, ciphertexts):
                 project.traces.append(
-                    cw.common.traces.Trace(wave, plaintext, bytearray(ciphertext), key)
+                    cw.common.traces.Trace(wave, plaintext, bytearray(ciphertext), key),
+                    dtype=np.uint16
                 )
             # Update the loop variable and the progress bar.
             rem_num_traces -= scope.num_segments

--- a/cw/cw305/simple_capture_traces_batch.py
+++ b/cw/cw305/simple_capture_traces_batch.py
@@ -79,6 +79,8 @@ def run_batch_capture(capture_cfg, ot, ktp, scope):
             # Transfer traces
             waves = scope.capture_and_transfer_waves()
             assert waves.shape[0] == scope.num_segments
+            # Check ADC output range
+            simple_capture.check_range(waves, ot.scope.adc.bits_per_sample)
             # Generate plaintexts and ciphertexts for the batch.
             # Note: Plaintexts are encrypted in parallel.
             plaintexts = [ktp.next()[1] for _ in range(scope.num_segments_actual)]

--- a/cw/cw305/util/device.py
+++ b/cw/cw305/util/device.py
@@ -114,18 +114,19 @@ class OpenTitan(object):
         scope.adc.basic_mode = "rising_edge"
         if hasattr(scope, '_is_husky') and scope._is_husky:
             # We sample using the target clock * 2 (200 MHz).
-            scope.adc.samples = num_samples
-            scope.clock.clkgen_freq = 100000000
-            scope.clock.clkgen_src = 'extclk'
             scope.clock.adc_mul = 2
+            scope.clock.clkgen_freq = 100000000
+            scope.adc.samples = num_samples
+            scope.clock.clkgen_src = 'extclk'
             husky = True
         else:
             # We sample using the target clock (100 MHz).
-            scope.adc.samples = num_samples // 2
+            scope.clock.adc_mul = 1
             scope.clock.clkgen_freq = 100000000
+            scope.adc.samples = num_samples // 2
+            offset = offset // 2
             scope.clock.adc_src = 'extclk_dir'
             husky = False
-            offset = offset // 2
         if offset >= 0:
             scope.adc.offset = offset
         else:

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -25,4 +25,4 @@ joblib
 # Development version of ChipWhisperer toolchain with latest features and
 # bug fixes - Needs to be installed in editable mode. We fix the version
 # for improved stability and manually update if necessary.
--e git+https://github.com/newaetech/chipwhisperer.git@99abbcad2bfdadee47dded973684a696b64a1c09#egg=chipwhisperer
+-e git+https://github.com/newaetech/chipwhisperer.git@1f8e73d07d180f1199fdff25d674c495c86e2ec8#egg=chipwhisperer


### PR DESCRIPTION
This reduced the memory footprint by 4x and will help us to capture more traces without immediately switching to a custom trace format and management. For this to work, some small changes in the ChipWhisperer API are required, see NewAETech/ChipWhisperer#401.