### PR TITLE
Switch to virtual Python env and install ChipWhisperer in editable mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ projects/
 
 # Python requirements source directory
 src/
+
+# Python virtual environment
+.venv/

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -59,13 +59,38 @@ machine or obtained using the provided [Dockerfile](https://github.com/lowRISC/o
 
 #### Installing on a Machine
 
+##### Python Virtual Environment
+
+To avoid potential dependency conflicts (in particular with the main OpenTitan
+repository which may be using a different version of ChipWhisperer) it is
+strongly recommended to setup a virtual Python environment for this repository.
+
+To this end, type
+```console
+$ python3 -m venv .venv
+```
+to create a new virtual environment.
+
+From this point on, whenever you want to work with this repository, type
+```console
+$ source .venv/bin/activate
+```
+to enable the virtual environment previously initialized.
+
+
 ##### Python Dependencies
 
-This repository has a couple of Python dependencies. You can run
+This repository has a couple of Python dependencies to be installed through
+`pip`. It is recommended to first install the latest version of `pip` and
+`setuptools` using
 ```console
-$ pip install --user -r python-requirements.txt
+python3 -m pip install -U pip setuptools
 ```
-to install those dependencies.
+You can then run
+```console
+$ pip install -r python-requirements.txt
+```
+to install all the required Python dependencies.
 
 
 ##### ChipWhisperer Dependencies

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -18,11 +18,11 @@ scared
 tqdm
 trsfile
 typer
+wheel
 # can be removed after switching to ray
 joblib
 
-# Development version of ChipWhisperer toolchain - Fix the version for now
-# Prefer the archive download over a git clone to decrease installation time
-# (The chipwhisperer repository is rather large and uses additionally uses
-# submodules, which need to be fetched as well.)
-https://github.com/newaetech/chipwhisperer/archive/99abbcad2bfdadee47dded973684a696b64a1c09.tar.gz
+# Development version of ChipWhisperer toolchain with latest features and
+# bug fixes - Needs to be installed in editable mode. We fix the version
+# for improved stability and manually update if necessary.
+-e git+https://github.com/newaetech/chipwhisperer.git@99abbcad2bfdadee47dded973684a696b64a1c09#egg=chipwhisperer


### PR DESCRIPTION
The officially recommended way of using ChipWhisperer is to install it in editable mode. We haven't done that so far because for OpenTitan a different version is installed (due to Python 3.6) and in non-editable mode (to speed up CI).

To again use ChipWhisperer in editable mode for ot-sca as recommended and to avoid issues due to having different versions installed in non-editable and editable mode, this commit now switches to a virtual Python environment for ot-sca.