### PR TITLE
Adjust CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,8 +13,8 @@
 #   https://help.github.com/en/articles/about-code-owners
 
 # Default Owners
-*                   @alphan @vogelpi @moidx
+*                   @abdullahvarici @alphan @andreaskurth @vogelpi @vrozic
 
 # License related files
-LICENSE*            @asb
-CLA*                @asb
+LICENSE*            @vogelpi
+CLA*                @vogelpi


### PR DESCRIPTION
This PR aligns the CODEOWNERS to correspond to the people currently most active on the repository..