### PR TITLE
Add typer CLI and yaml file support to tvla script.

### DIFF
--- a/cw/tvla_cfg_template.yaml
+++ b/cw/tvla_cfg_template.yaml
@@ -1,0 +1,15 @@
+project_file: projects/opentitan_simple_aes.cwp
+trace_file: null
+trace_start: null
+trace_end: null
+leakage_file: null
+save_to_disk: null
+round_select: null
+byte_select: null
+input_file: null
+output_file: null
+number_of_steps: 1
+ttest_step_file: null
+plot_figures: false
+general_test: true
+mode: aes

--- a/test/tvla_test.py
+++ b/test/tvla_test.py
@@ -18,7 +18,7 @@ class TvlaCmd(RepoCmd):
 def test_help():
     tvla = TvlaCmd(Args('--help')).run()
     # Assert that a message is printed on stdout or stderr.
-    assert(len(tvla.stdout()) != 0 or len(tvla.stderr()) != 0)
+    assert (len(tvla.stdout()) != 0 or len(tvla.stderr()) != 0)
 
 
 def ttest_significant(ttest_trace) -> bool:
@@ -30,13 +30,15 @@ def ttest_significant(ttest_trace) -> bool:
 
 def test_general_leaking_histogram():
     hist_path = TestDataPath('tvla_general/sha3_hist_leaking.npz')
-    tvla = TvlaCmd(Args(f'-g -m sha3 -i {hist_path}')).run()
+    tvla = TvlaCmd(Args(['--input-file', str(hist_path),
+                        '--mode', 'sha3', 'run-tvla'])).run()
     assert ttest_significant(np.load('tmp/ttest.npy')), (
            f"{tvla} did not find significant leakage, which is unexpected")
 
 
 def test_general_nonleaking_histogram():
     hist_path = TestDataPath('tvla_general/sha3_hist_nonleaking.npz')
-    tvla = TvlaCmd(Args(f'-g -m sha3 -i {hist_path}')).run()
+    tvla = TvlaCmd(Args(['--input-file', str(hist_path),
+                        '--mode', 'sha3', 'run-tvla'])).run()
     assert not ttest_significant(np.load('tmp/ttest.npy')), (
            f"{tvla} did find significant leakage, which is unexpected")


### PR DESCRIPTION
Default configurations are specified in yaml file and
it is possible to overwrite them over command line interface.
This is provided by typer library. It also provides descriptions
when typed --help. Updated configurations are written into
a .yaml file after analysis.

Signed-off-by: Abdullah Varici <abdullah.varici@lowrisc.org>