### PR TITLE
Trigger lintpy workflow on pull requests

### DIFF
--- a/.github/workflows/lintpy.yml
+++ b/.github/workflows/lintpy.yml
@@ -4,8 +4,11 @@ name: lintpy
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push events
+  # Triggers the workflow on pushes to master and on pull requests (to any branch)
   push:
+    branches:
+      - master
+  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Without the `pull_request` event, the workflow would only trigger on
pushes to branches in the repository.  When pushing to a forked branch,
the workflow would not trigger.  Thus, the `pull_request` event is
required to trigger the workflow in PRs.  The `push` event restricted to
the `master` branch additionally covers pushes directly to the master
branch, without creating a duplicate check on pushes to pull request
branches.