### PR TITLE
Compress TVLA general test data

### DIFF
--- a/test/data/tvla_general/sha3_hist_leaking.npz
+++ b/test/data/tvla_general/sha3_hist_leaking.npz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e34ee97d18a6e733e2f1f5e98bf007f78b2ed3b204de537d5ee621b518f3acd8
-size 52433044
+oid sha256:08d633ffdefedd081d390fc324d92af1a2a9a44cf8fe70a1edf11103bf2a0777
+size 283617

--- a/test/data/tvla_general/sha3_hist_nonleaking.npz
+++ b/test/data/tvla_general/sha3_hist_nonleaking.npz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2973321d8245ec39301461f5eef1a85dac27121f3cbc868d293bb69685fa898
-size 104865044
+oid sha256:b338003ce2cf8eecc671dc3e5da2d5971b95e96ab0fb698c9c094d5859bbccae
+size 522015


### PR DESCRIPTION
This commit compresses the existing test data for the general TVLA test
with `np.savez_compressed()`.  No changes are required to the code, which
can continue to load the data with a simple `np.load()`.  The total file
size of the existing tests is reduced from >150 MiB to <1 MiB.  The
execution time of the tests does not increase measurably.

Part of #96.