### PR TITLE
Add support for KMAC SW key masking

### DIFF
--- a/cw/capture.py
+++ b/cw/capture.py
@@ -577,6 +577,7 @@ def capture_sha3_fvsr_key_batch(ot, ktp, capture_cfg, scope_type):
     ot.target.simpleserial_write("t", key_fixed)
     key = key_fixed
     random.seed(capture_cfg["batch_prng_seed"])
+    ot.target.simpleserial_write("l", capture_cfg["lfsr_seed"].to_bytes(4, "little"))
     ot.target.simpleserial_write("s", capture_cfg["batch_prng_seed"].to_bytes(4, "little"))
 
     # Create the ChipWhisperer project.
@@ -661,7 +662,7 @@ def sha3_random(ctx: typer.Context,
     capture_end(ctx.obj.cfg)
 
 
-def capture_sha3_fvsr_key(ot):
+def capture_sha3_fvsr_key(ot, capture_cfg):
     """A generator for capturing SHA3 (KMAC) traces.
     The data collection method is based on the derived test requirements (DTR) for TVLA:
     https://www.rambus.com/wp-content/uploads/2015/08/TVLA-DTR-with-AES.pdf
@@ -690,6 +691,7 @@ def capture_sha3_fvsr_key(ot):
     text_len = len(text_fixed)
 
     tqdm.write(f'Using fixed key: {binascii.b2a_hex(bytes(key_fixed))}')
+    ot.target.simpleserial_write("l", capture_cfg["lfsr_seed"].to_bytes(4, "little"))
 
     # Start sampling with the fixed key.
     sample_fixed = 1
@@ -729,7 +731,8 @@ def sha3_fvsr_key(ctx: typer.Context,
                   plot_traces: int = opt_plot_traces):
     """Capture SHA3 (KMAC) traces from a target that runs the `sha3_serial` program."""
     capture_init(ctx, num_traces, plot_traces)
-    capture_loop(capture_sha3_fvsr_key(ctx.obj.ot), ctx.obj.ot, ctx.obj.cfg["capture"])
+    capture_loop(capture_sha3_fvsr_key(ctx.obj.ot, ctx.obj.cfg["capture"]),
+                 ctx.obj.ot, ctx.obj.cfg["capture"])
     capture_end(ctx.obj.cfg)
 
 

--- a/cw/capture_sha3_cw310.yaml
+++ b/cw/capture_sha3_cw310.yaml
@@ -21,6 +21,14 @@ capture:
   #offset: 860
   # w/ DOM
   offset: 2300
+  # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
+  # For unprotected implemetation, lfsr_seed should be set to 0. This will
+  # effectively switch off the masking. For masked implementation, any seed
+  # other than 0 should be used.
+  # w/o DOM
+  #lfsr_seed: 0
+  # w/ DOM
+  lfsr_seed: 0xdeadbeef
   scope_gain: 27
   num_traces: 5000
   project_name: projects/opentitan_simple_sha3

--- a/cw/objs/sha3_serial_fpga_cw310.bin
+++ b/cw/objs/sha3_serial_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b58689311f797e5a422e39b6d1ec25270df262532d04d2e9dce39d7f7ca8272
-size 13044
+oid sha256:4023fa2b110c7ddf2d8be132e7acf5ad0e36c90df25620edae9d7153606eb3d6
+size 13224


### PR DESCRIPTION
KMAC key shares are masked in SW using a 32-bit LFSR.
This commit enables user to specify the LFSR seed in the
configuration file. This feature is needed because unmasked
implementations don't support SW key masking. By re-seeding
LFSR to 0, SW key-masking can be effectively switched off.

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>