### PR TITLE
[docker/podman] Rework container, switch to podman

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !python-requirements.txt
+!python-requirements-lint.txt
 !util/docker

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -142,17 +142,20 @@ Alternatively, you can rebuild those binaries yourself from the
 
 #### Using the Docker Image
 
-**Note**: This is a WIP and currently supports only Linux hosts.
+**Notes**:
+- While the provided container image can be run using the Docker Engine, this
+  getting started guide relies on Podman instead to avoid requiring root
+  permissions on the host.
+- This is a WIP and currently supports Linux hosts only.
 
 The
 [Dockerfile](https://github.com/lowRISC/ot-sca/blob/master/util/docker/Dockerfile)
 in this repository can be used to build a ready-to-use image with all the
 dependencies installed. To build the image:
-1. If not already installed, install the Docker Engine following the instructions
-[here](https://docs.docker.com/engine/install/), and
+1. If not already installed, install Podman following the instructions
+[here](https://podman.io/getting-started/installation), and
 2. Build the container image using
 [build\_image.sh](https://github.com/lowRISC/ot-sca/blob/master/util/docker/build_image.sh):
-(you may have to use `sudo` to be able to run docker commands depending on your setup):
 ```console
 $ util/docker/build_image.sh
 ```

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -54,8 +54,6 @@ The following, alternative hardware equipment is partially supported:
 Software required by this repository can either be directly installed on a
 machine or obtained using the provided [Dockerfile](https://github.com/lowRISC/ot-sca/blob/master/util/docker/Dockerfile).
 
-**Note**: The Dockerfile may need updating. For details, see https://github.com/lowRISC/ot-sca/issues/58.
-
 
 #### Installing on a Machine
 
@@ -153,7 +151,7 @@ dependencies installed. To build the image:
 1. If not already installed, install the Docker Engine following the instructions
 [here](https://docs.docker.com/engine/install/), and
 2. Build the container image using
-[build\_image.sh](https://github.com/lowRISC/ot-sca/blob/master/util/docker/run_container.sh)
+[build\_image.sh](https://github.com/lowRISC/ot-sca/blob/master/util/docker/build_image.sh):
 (you may have to use `sudo` to be able to run docker commands depending on your setup):
 ```console
 $ util/docker/build_image.sh

--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Docker file for OpenTitan side channel analysis and fault injection.
+# Docker file for OpenTitan side channel analysis and fault injection setup.
 
 FROM ubuntu:18.04
 
@@ -18,6 +18,7 @@ ARG TIME_ZONE=America/New_York
 # support python 3.9 yet.
 ARG PYTHON=python3.8
 ARG VENV_PATH=/opt/venv
+ARG GCC_VERSION=9
 
 # Use bash as the default shell.
 SHELL ["/bin/bash", "-c"]
@@ -45,10 +46,19 @@ ENV LC_ALL=en_US.UTF-8
 RUN ln -fs /usr/share/zoneinfo/"${TIME_ZONE}" /etc/localtime
 RUN dpkg-reconfigure -f noninteractive tzdata
 
+# Install the CI version of gcc and g++
+RUN apt-get install --no-install-recommends -y software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
+    && apt-get update \
+    && apt-get install -y gcc-${GCC_VERSION} g++-${GCC_VERSION} \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 90 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 90
+
 # Chipwhisperer dependencies.
-# https://chipwhisperer.readthedocs.io/en/latest/prerequisites.html
+# https://chipwhisperer.readthedocs.io/en/latest/linux-install.html#required-packages
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
     libusb-dev \
+    libusb-1.0-0-dev \
     make
 
 # Python virtual environment and dependencies.
@@ -62,6 +72,7 @@ RUN "${PYTHON}" -m venv "${VENV_PATH}"
 ENV PATH="${VENV_PATH}"/bin:"${PATH}"
 ENV VIRTUAL_ENV="${VENV_PATH}"
 COPY python-requirements.txt /tmp/python-requirements.txt
+COPY python-requirements-lint.txt /tmp/python-requirements-lint.txt
 RUN pip install --upgrade pip && \
     pip install -r /tmp/python-requirements.txt && \
     chmod -R o=u "${VENV_PATH}";

--- a/util/docker/build_image.sh
+++ b/util/docker/build_image.sh
@@ -6,4 +6,4 @@
 readonly IMAGE_NAME='ot-sca'
 readonly DOCKERFILE='util/docker/Dockerfile'
 
-docker build -t ${IMAGE_NAME} -f ${DOCKERFILE} .
+podman build -t ${IMAGE_NAME} -f ${DOCKERFILE} . --format docker

--- a/util/docker/run_container.sh
+++ b/util/docker/run_container.sh
@@ -57,7 +57,7 @@ if [[ -z "${HOST_WORK_DIR}" ]] || [[ -z "${SHM_SIZE}" ]] || [[ ${#DEVICES[@]} -e
   error "Missing options: '-m SHM_SIZE', '-w HOST_WORK_DIR', and '-d DEVICE' are required."
 fi
 
-docker run --rm -it \
+podman run --rm -it \
     --shm-size "${SHM_SIZE}" \
     -v "${HOST_WORK_DIR}":"${CONTAINER_WORK_DIR}" \
     -w "${CONTAINER_WORK_DIR}" \

--- a/util/docker/run_container.sh
+++ b/util/docker/run_container.sh
@@ -10,7 +10,7 @@ CONTAINER_NAME=${IMAGE_NAME}
 function usage() {
   cat <<USAGE
 
-Run OpenTitan SCA/FI image.
+Run OpenTitan SCA/FI container.
 
 Usage: $0 -d DEVICE [-d DEVICE] -m SHM_SIZE -w HOST_WORK_DIR [-n CONTAINER_NAME] [-h]
  


### PR DESCRIPTION
This PR contains two commits to update the Dockerfile and switch from docker to podman which doesn't require root permissions on the host. This is what we use on our workstation and we might do the same switch also for OpenTitan at some point. At the moment, the generated image is still compatible with docker.