### PR TITLE
[util/device.py] Wait for ADC lock instead of aborting after first trial

### DIFF
--- a/cw/util/device.py
+++ b/cw/util/device.py
@@ -158,7 +158,16 @@ class OpenTitan(object):
         if not husky:
             scope.clock.reset_adc()
             time.sleep(0.5)
-        assert (scope.clock.adc_locked), "ADC failed to lock"
+
+        # Wait for ADC to lock.
+        ping_cnt = 0
+        while not scope.clock.adc_locked:
+            if ping_cnt == 3:
+                raise RuntimeError(
+                    f'ADC failed to lock (attempts: {ping_cnt}).')
+            ping_cnt += 1
+            time.sleep(0.5)
+
         return scope
 
     def initialize_target(self, programmer, firmware, baudrate, output_len,


### PR DESCRIPTION
The scope uses the clock provided from the target and depending on the target, it may take some more time for the ADC to actually lock on the clock. With this commit, we wait for up to 1.5s for the ADC to lock instead of just aborting the capture if the ADC hasn't locked yet when first checked.
