### PR TITLE
[kmac] Update bitstream and binary

### DIFF
--- a/cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
+++ b/cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b97df8b522ea63df3d04b96b6cf9d296d7723d0f39b506391d4ebabb08b3498
+oid sha256:92f5e533e444be87cf349b38f9b0f8393c89830bcc89e5741ce7f8694e4202df
 size 15878032

--- a/cw/objs/sha3_serial_fpga_cw310.bin
+++ b/cw/objs/sha3_serial_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4023fa2b110c7ddf2d8be132e7acf5ad0e36c90df25620edae9d7153606eb3d6
-size 13224
+oid sha256:e3a8ec3669cc19894208af6f26de07731b17038a109efa48a79593ea439be003
+size 19116


### PR DESCRIPTION
Update KMAC bitstream to https://github.com/lowRISC/opentitan/commit/a029fa5c6

The previous version of the bitstream doesn't work with newly generated
binaries.

This bitstream was generated from a recent OpenTitan commit with several
changes applied on top:
    KMAC masking enabled
    AES masking switched off
    OTBN stubbed
    Scrambling disabled in flash_ctrl

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>