### PR TITLE
[python-requirements] Pin setuptools version to < 66.0.0

### DIFF
--- a/.github/workflows/lintpy.yml
+++ b/.github/workflows/lintpy.yml
@@ -29,7 +29,7 @@ jobs:
         run: python3 -m venv .venv; source .venv/bin/activate
 
       - name: Install Python dependencies
-        run: python3 -m pip install -U pip setuptools; pip install -r python-requirements-lint.txt
+        run: python3 -m pip install -U pip "setuptools<66.0.0"; pip install -r python-requirements-lint.txt
 
       - name: Run lintpy.py
         run: ./util/lintpy.sh

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,7 +31,7 @@ jobs:
         run: python3 -m venv .venv; source .venv/bin/activate
 
       - name: Install Python dependencies
-        run: python3 -m pip install -U pip setuptools; pip install -r python-requirements.txt
+        run: python3 -m pip install -U pip "setuptools<66.0.0"; pip install -r python-requirements.txt
 
       - name: Run pytest
         run: pytest test

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -82,7 +82,7 @@ This repository has a couple of Python dependencies to be installed through
 `pip`. It is recommended to first install the latest version of `pip` and
 `setuptools` using
 ```console
-python3 -m pip install -U pip setuptools
+python3 -m pip install -U pip "setuptools<66.0.0"
 ```
 You can then run
 ```console

--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -73,7 +73,7 @@ ENV PATH="${VENV_PATH}"/bin:"${PATH}"
 ENV VIRTUAL_ENV="${VENV_PATH}"
 COPY python-requirements.txt /tmp/python-requirements.txt
 COPY python-requirements-lint.txt /tmp/python-requirements-lint.txt
-RUN pip install --upgrade pip && \
+RUN pip install --upgrade pip "setuptools<66.0.0" && \
     pip install -r /tmp/python-requirements.txt && \
     chmod -R o=u "${VENV_PATH}";
 


### PR DESCRIPTION
Starting with setuptools version 66.0.0, legacy package version names such as 1.1build1 are no longer supported. Since some of our Python dependencies use this format, we pin the setuptools version to the last version before this change. This unblocks CI and gives us time to upgrade/rebase our dependencies.