### PR TITLE
[tvla] Add function for plotting average and variance traces and diffs

### DIFF
--- a/cw/capture.py
+++ b/cw/capture.py
@@ -109,7 +109,7 @@ def plot_results(plot_cfg, project_name):
         print('Project contains no traces. Did the capture fail?')
         return
 
-    plot.save_plot_to_file(project.waves, plot_cfg["num_traces"],
+    plot.save_plot_to_file(project.waves, None, plot_cfg["num_traces"],
                            plot_cfg["trace_image_filename"])
     print(
         f'Created plot with {plot_cfg["num_traces"]} traces: '

--- a/cw/util/plot.py
+++ b/cw/util/plot.py
@@ -10,14 +10,27 @@ from bokeh.palettes import Dark2_5 as palette
 from bokeh.plotting import figure, show
 
 
-def save_plot_to_file(traces, num_traces, outfile):
+def save_plot_to_file(traces, set_indices, num_traces, outfile):
     """Save plot figure to file."""
-    colors = itertools.cycle(palette)
+    if set_indices is None:
+        colors = itertools.cycle(palette)
+    else:
+        assert len(traces) == len(set_indices)
+        # set_indices[x] indicates to which set trace x belongs.
+        trace_colors = []
+        for i in range(len(set_indices)):
+            color_idx = set_indices[i] % len(palette)
+            trace_colors.append(palette[color_idx])
+        # Generate iterable from list.
+        colors = itertools.cycle(tuple(trace_colors))
     xrange = range(len(traces[0]))
     plot = figure(plot_width=800)
     plot.add_tools(tools.CrosshairTool())
     plot.add_tools(tools.HoverTool())
     for i in range(min(len(traces), num_traces)):
-        plot.line(xrange, traces[i], line_color=next(colors))
+        if set_indices is None:
+            plot.line(xrange, traces[i], line_color=next(colors))
+        else:
+            plot.line(xrange, traces[i], line_color=next(colors), legend_label=str(set_indices[i]))
     output_file(outfile)
     show(plot)


### PR DESCRIPTION
These functions are particularly useful when debugging e.g. cases where the t-test results are not centered around 0.

Below figures show some example plots for SHA3 where I used this to debug a "fake" leakage issue.

1. The average fixed and random trace. They cannot really be distinguished here.
![bokeh_plot](https://user-images.githubusercontent.com/20307557/221805432-1a83290a-85d7-4738-b3c8-30c34f6bd0a4.png)

2. The difference between the fixed and random trace average. We see a big peak at the very beginning where the plaintext is loaded. Then the difference slowly and almost linearly decreases while the target is completely idle. This is when the power rails recharge from the initial plaintext loading.
![bokeh_plot(1)](https://user-images.githubusercontent.com/20307557/221805447-89d6e2d4-ae1b-43d0-8cb2-dca5ac51511e.png)

3. The variance for the fixed and random trace set.
![bokeh_plot(2)](https://user-images.githubusercontent.com/20307557/221805453-ec553468-b86f-43fa-8bca-7f77430540a1.png)

4. The difference between the fixed and random trace variance.
![bokeh_plot(3)](https://user-images.githubusercontent.com/20307557/221805467-459d0c7c-5b9d-4b32-b810-1f62e7cabab6.png)

5. The resulting TVLA plot. We can see the resulting fake leakage during the idle period and spanning into the SHA3 processing where it covers potential real leakage. These newly added figures are useful to debug such issues.
![tvla](https://user-images.githubusercontent.com/20307557/221807347-1e7ec72b-beea-4668-99e1-34a47ce06905.png)

FYI: to reduce the fake leakage one has to change the fixed plaintext to something more uniform, for details see #122 . 