### PR TITLE
[otbn/tvla] Add bitstream + device binary for OTBN vertical TVLA

### DIFF
--- a/cw/objs/ecc256_keygen_serial_fpga_cw310.bin
+++ b/cw/objs/ecc256_keygen_serial_fpga_cw310.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89ee69ef03850a56546f425be9cfcc8a0e4e1aaa79acc4f6eefb0d7d8ae39f90
+size 32508

--- a/cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1_ecdsa.bit
+++ b/cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1_ecdsa.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61b26cfa376d0daed32ad8d25be4f00e3dbfbe6a94cc83faf65f3a8438794de1
+oid sha256:c0fa99bf554329361f1b8bac1603cac2c012bcd1a1e492efed56408b2a8f761c
 size 15878032


### PR DESCRIPTION
Adds bitstream with switched off OTBN URND
Bitstream taken from lowrisc master after commit:
https://github.com/lowRISC/opentitan/commit/3f64068d649cf21581f53b241ae7fbfb153c335d 
Corresponding PRs are:
https://github.com/lowRISC/opentitan/pull/17195
and
https://github.com/lowRISC/opentitan/pull/17223

Adds ecc256 keygen serial device binary
Binary compiled from:
https://github.com/jadephilipoom/opentitan/commit/b5a29028c0727452bb207dbbdef66741fb3fce20

Required for https://github.com/lowRISC/ot-sca/pull/115