### PR TITLE
[otbn/tvla] add option to configure the used samples per trace

### DIFF
--- a/cw/tvla_cfg_otbn.yaml
+++ b/cw/tvla_cfg_otbn.yaml
@@ -14,3 +14,5 @@ plot_figures: true
 general_test: true
 mode: otbn
 key_len_bytes: 40
+sample_start: null
+num_samples : 4000

--- a/cw/tvla_cfg_template.yaml
+++ b/cw/tvla_cfg_template.yaml
@@ -13,3 +13,6 @@ ttest_step_file: null
 plot_figures: false
 general_test: true
 mode: aes
+# Only enabled for otbn mode.
+sample_start: null 
+num_samples : null


### PR DESCRIPTION
This option is currently only available for traces with `dtype=np.uint16`
Do we still support traces with `dtype=np.double`?

It is only tested for otbn and rises a runtime error if used for other modes.

See also: https://github.com/lowRISC/ot-sca/issues/72