### PR TITLE
Enhance status print while programming the FPGA

### DIFF
--- a/cw/util/device.py
+++ b/cw/util/device.py
@@ -76,7 +76,7 @@ class OpenTitan(object):
         # bitstream.
         # TODO: We should have this in the CLI.
         force_programming = False
-        print('Connecting and loading FPGA... ', end='')
+        print('Connecting and loading FPGA... ', end='', flush = True)
 
         # Runtime patch fpga.fpga.FPGAProgram to detect if it was actually called.
         # Note: This is fragile and may break but it is easy to miss that the FPGA


### PR DESCRIPTION
At the moment the "Connecting and loading FPGA..." is only printed after the FPGA is actually programmed.
This is kind of annoying, because programming the FPGA takes some time and nothing is printed during that time.
As this is the very first message to be printed, it is not obvious what's going on and if the python script is running as expected.