### PR TITLE
[otbn/tvla] Add batch mode for OTBN vertical ecc256 keygen capture

### DIFF
--- a/cw/capture_otbn_vertical.yaml
+++ b/cw/capture_otbn_vertical.yaml
@@ -2,7 +2,8 @@ device:
   fpga_bitstream: objs/lowrisc_systems_chip_earlgrey_cw310_0.1_ecdsa.bit
   fw_bin: objs/ecc256_keygen_serial_fpga_cw310.bin
   # Target operating frequency
-  pll_frequency: 91000000
+  # For non-batch mode max. 91 MHz, otherwise serial communication fails
+  pll_frequency: 100000000
   baudrate: 115200
 capture:
   # Currently, 'p256' is the only supported curve.
@@ -18,12 +19,13 @@ capture:
   output_len_bytes: 40
   # Samples per trace
   # Fifo Size is 131070 = max num samples to avoid multiple runs per trace
-  num_samples: 8000
+  num_samples: 3500
   # Offset in samples
   offset: 0
   # scope gain in db
   scope_gain: 24
   num_traces: 1000
+  batch_prng_seed: 6
   project_name: projects/opentitan_otbn_vertical_keygen
   waverunner_ip: 192.168.1.228
   # As OTBN operations are long, we may need to overwrite the following

--- a/cw/tvla_cfg_otbn.yaml
+++ b/cw/tvla_cfg_otbn.yaml
@@ -15,4 +15,4 @@ general_test: true
 mode: otbn
 key_len_bytes: 40
 sample_start: null
-num_samples : 4000
+num_samples : 3500


### PR DESCRIPTION
This commit adds 

- A batch mode capture function for OTBN vertical ecc256 keygen analysis.
- Additional capture and tvla config files suitable to run with the batch mode (configuration parameters have to be different to the non-batch mode).

The batch mode increases the capture rate, compared to non-batch mode, by approx. 2000% (at least on my FPGA setup). (Before: ca. 20 Traces/s, Now: ca. 400 Traces/s)

First TVLA results look good: (first plot: masks off, 10k traces, second plot: masks on, 40k traces)

![otbn_fixed_vs_random_batch_mask_off_10k_traces](https://user-images.githubusercontent.com/37845504/222699197-d6825e14-0ae3-4e9b-a64f-dc3f0cd2787f.png)
![otbn_fixed_vs_random_batch_mask_on_40k_traces](https://user-images.githubusercontent.com/37845504/222699231-39ef41a7-f691-4de9-8ebe-f348807febd7.png)


Once the corresponding PR for the serial device code (https://github.com/lowRISC/opentitan/pull/17416) is merged I'll open another PR for the built binary.