### PR TITLE
[otbn/tvla] Add binary for OTBN vertical batch mode

### DIFF
--- a/cw/objs/ecc256_keygen_serial_fpga_cw310.bin
+++ b/cw/objs/ecc256_keygen_serial_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89ee69ef03850a56546f425be9cfcc8a0e4e1aaa79acc4f6eefb0d7d8ae39f90
-size 32508
+oid sha256:c310e41ada9a140ac9930aba6e0affa27e5f63c2bf5dd3314ee2b927a0e9c799
+size 34848


### PR DESCRIPTION
Adds ecc256 keygen serial device binary
Binary compiled from lowrisc OT master after commit: https://github.com/lowRISC/opentitan/commit/894278fb9d7cad111ed715856c0c06a565c366b7