### PR TITLE
[tvla] Consider offset in trace/tvla plots for trigger highlighting

### DIFF
--- a/cw/tvla.py
+++ b/cw/tvla.py
@@ -979,7 +979,9 @@ def run_tvla(ctx: typer.Context):
                 trigger_samples = int(
                     project.config['ChipWhisperer']['General Settings']
                     ['samples_trigger_high'])
-                trigger_high = trigger_samples - sample_start
+                offset = int(project.config['ChipWhisperer']
+                             ['General Settings']['offset'])
+                trigger_high = trigger_samples - (sample_start + offset)
                 if trigger_high < 0:
                     trigger_high = 0
                 axs[0].set_ylabel("trace")


### PR DESCRIPTION
So far, when capturing traces with offset, the offset isn't taken into account when generating the TVLA plots. This means the trigger highlighting doesn't work properly, when an offset is configured.
This commit/PR fixes this.