### PR TITLE
[aes] Add separate SW LFSR for key masking

### DIFF
--- a/cw/capture.py
+++ b/cw/capture.py
@@ -455,7 +455,8 @@ def capture_aes_fvsr_key_batch(ot, ktp, capture_cfg, scope_type, gen_ciphertexts
     # Seed host's PRNG.
     # TODO: Replace this with a dedicated PRNG to avoid other packages breaking our code.
     random.seed(capture_cfg["batch_prng_seed"])
-    # Seed the target's PRNG
+    # Seed the target's PRNGs
+    ot.target.simpleserial_write("l", capture_cfg["lfsr_seed"].to_bytes(4, "little"))
     ot.target.simpleserial_write("s", capture_cfg["batch_prng_seed"].to_bytes(4, "little"))
 
     # Set and transfer the fixed key.
@@ -521,10 +522,6 @@ def capture_aes_fvsr_key_batch(ot, ktp, capture_cfg, scope_type, gen_ciphertexts
                 expected_last_ciphertext = ciphertexts[-1]
             else:
                 expected_last_ciphertext = np.asarray(scared.aes.base.encrypt(plaintext, key))
-
-            # dummy operation for synching PRNGs with the firmware when using key sharing
-            for ii in range(scope.num_segments_actual):
-                _ = np.asarray(ktp.next()[1])
 
             check_ciphertext(ot, expected_last_ciphertext, 4)
 

--- a/cw/capture_aes_cw305.yaml
+++ b/cw/capture_aes_cw305.yaml
@@ -1,7 +1,7 @@
 device:
   fpga_bitstream: objs/lowrisc_systems_chip_englishbreakfast_cw305_0.1.bit
   force_program_bitstream: False
-  fw_bin: objs/aes_serial_fpga_nexysvideo.bin
+  fw_bin: objs/aes_serial_fpga_cw305.bin
   pll_frequency: 100000000
   baudrate: 115200
 capture:
@@ -16,12 +16,15 @@ capture:
   # cycle later (20 samples) and there are 2 synchronization stages at 100 MHz
   # at the top level (4 samples).
   offset: -40
-  scope_gain: 19
+  # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
+  # To switch off the masking, 0 must be used as LFSR seed.
+  lfsr_seed: 0xdeadbeef
+  batch_prng_seed: 0
+  scope_gain: 20
   num_traces: 5000
   project_name: projects/opentitan_simple_aes
   waverunner_ip: 192.168.1.228
-  batch_prng_seed: 0
 plot_capture:
   show: true
-  num_traces: 10
+  num_traces: 100
   trace_image_filename: projects/sample_traces_aes.html

--- a/cw/capture_aes_cw310.yaml
+++ b/cw/capture_aes_cw310.yaml
@@ -16,11 +16,14 @@ capture:
   # cycle later (20 samples) and there are 2 synchronization stages at 100 MHz
   # at the top level (4 samples).
   offset: -40
-  scope_gain: 26.5
+  # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
+  # To switch off the masking, 0 must be used as LFSR seed.
+  lfsr_seed: 0xdeadbeef
+  batch_prng_seed: 0
+  scope_gain: 31.5
   num_traces: 5000
   project_name: projects/opentitan_simple_aes
   waverunner_ip: 192.168.1.228
-  batch_prng_seed: 0
 plot_capture:
   show: true
   num_traces: 100

--- a/cw/objs/aes_serial_fpga_cw305.bin
+++ b/cw/objs/aes_serial_fpga_cw305.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5c0f8b459ef9a65fc6824254dbb8d6ccc16194f22c9d2a37004c38ee8f68f18
+size 29632

--- a/cw/objs/aes_serial_fpga_cw310.bin
+++ b/cw/objs/aes_serial_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:315ac918e2605205f981c72bd8ef49ddc8610cbfd275b72d8fc6a0922ea3afa2
-size 13096
+oid sha256:3e085a84a93330e430d676554e079bdf1917843f82d1e7cef442b9265f0fd57b
+size 34216

--- a/cw/objs/aes_serial_fpga_nexysvideo.bin
+++ b/cw/objs/aes_serial_fpga_nexysvideo.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad8b289d44e068d648126216213604573f12ba59476c7e8c2960c07ac9d35543
-size 12192

--- a/cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit
+++ b/cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65ec762612cd60c8aa1df04c4ec987de26bafa606808ac3c457b9d9efe564a68
+oid sha256:403c747bb6c234ca4cb2181235293b30756ff9ee9827ae5c2adddae5fb5c8e3d
 size 15878032

--- a/cw/objs/lowrisc_systems_chip_englishbreakfast_cw305_0.1.bit
+++ b/cw/objs/lowrisc_systems_chip_englishbreakfast_cw305_0.1.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa85f9dce204fc222222dcb310564ba2a78ccceb282aee1b2da594323427d611
+oid sha256:42827487ad753b69d810afb11953b284321e1b42b360ab519a8437f06ffc8386
 size 3825912


### PR DESCRIPTION
This requires the AES target binaries to be updated as well. I'll publish a PR for the changes to `aes_serial.c` upstream and then add the updated binaries to this PR as well.