### PR TITLE
Keygen batch fvsr key

### DIFF
--- a/cw/capture.py
+++ b/cw/capture.py
@@ -1616,14 +1616,43 @@ def capture_otbn_vertical_batch(ot, ktp, capture_cfg, scope_type, device_cfg):
         ot.target.simpleserial_write("s", capture_cfg["batch_prng_seed"].to_bytes(4, "little"))
         time.sleep(0.3)
 
-        # set ecc256 fixed seed
-        seed_fixed = ktp.next_key()
+        # Generate fixed constants for all traces of the keygen operation.
+
+        if capture_cfg["test_type"] == 'KEY':
+            # In fixed-vs-random KEY mode we use two fixed constants:
+            #    1. C - a 320 bit constant redundancy
+            #    2. fixed_number - a 256 bit number used to derive the fixed key
+            #                      for the fixed set of measurements. Note that in
+            #                      this set, the fixed key is equal to
+            #                      (C + fixed_number) mod curve_order_n
+            C = ktp.next_key()
+            if len(C) != seed_bytes:
+                raise ValueError(f'Fixed seed length is {len(C)}, expected {seed_bytes}')
+            ktp.key_len = key_bytes
+            fixed_number = ktp.next_key()
+            if len(fixed_number) != key_bytes:
+                raise ValueError(f'Fixed key length is {len(fixed_number)}, expected {key_bytes}')
+            ktp.key_len = seed_bytes
+            C_int = int.from_bytes(C, byteorder='little')
+            seed_fixed_int = C_int + int.from_bytes(fixed_number, byteorder='little')
+            seed_fixed = seed_fixed_int.to_bytes(seed_bytes, byteorder='little')
+
+            print("Constant redundancy:")
+            print(binascii.b2a_hex(C))
+            ot.target.simpleserial_write("c", C_int.to_bytes(40, "little"))
+            time.sleep(0.3)
+        else:
+            # In fixed-vs-random SEED mode we use only one fixed constant:
+            #    1. seed_fixed - A 320 bit constant used to derive the fixed key
+            #                    for the fixed set of measurements. Note that in
+            #                    this set, the fixed key is equal to:
+            #                    seed_fixed mod curve_order_n
+            seed_fixed = ktp.next_key()
+            if len(seed_fixed) != seed_bytes:
+                raise ValueError(f'Fixed seed length is {len(seed_fixed)}, expected {seed_bytes}')
+
         print("Fixed seed:")
         print(binascii.b2a_hex(seed_fixed))
-        if len(seed_fixed) != seed_bytes:
-            raise ValueError(
-                f'Fixed seed length is {len(seed_fixed)}, expected {seed_bytes}'
-            )
         ot.target.simpleserial_write("x", seed_fixed)
         time.sleep(0.3)
 
@@ -1633,6 +1662,14 @@ def capture_otbn_vertical_batch(ot, ktp, capture_cfg, scope_type, device_cfg):
         else:
             ot.target.simpleserial_write("m", bytearray([0x01]))
         time.sleep(0.3)
+
+        # Re-seeding the PRNG in the KEY mode. In this mode, the PRNG produces additional 32 bytes
+        # to set up the fixed_number.
+        # This is a necessary step to sync with the PRNG on the capture side.
+        if capture_cfg["test_type"] == 'KEY':
+            random.seed(capture_cfg["batch_prng_seed"])
+            ot.target.simpleserial_write("s", capture_cfg["batch_prng_seed"].to_bytes(4, "little"))
+            time.sleep(0.3)
 
         with tqdm(total=rem_num_traces,
                   desc="Capturing",
@@ -1645,8 +1682,13 @@ def capture_otbn_vertical_batch(ot, ktp, capture_cfg, scope_type, device_cfg):
 
                 scope.arm()
                 # Start batch keygen
-                ot.target.simpleserial_write(
-                    "b", scope.num_segments_actual.to_bytes(4, "little"))
+                if capture_cfg["test_type"] == 'KEY':
+                    ot.target.simpleserial_write(
+                        "e", scope.num_segments_actual.to_bytes(4, "little"))
+                else:
+                    ot.target.simpleserial_write(
+                        "b", scope.num_segments_actual.to_bytes(4, "little"))
+
                 # Transfer traces
                 waves = scope.capture_and_transfer_waves()
                 assert waves.shape[0] == scope.num_segments
@@ -1664,12 +1706,25 @@ def capture_otbn_vertical_batch(ot, ktp, capture_cfg, scope_type, device_cfg):
                 batch_digest = None
                 for i in range(scope.num_segments_actual):
 
-                    if sample_fixed:
-                        seed_barray = seed_fixed
-                        seed = int.from_bytes(seed_barray, "little")
+                    if capture_cfg["test_type"] == 'KEY':
+                        if sample_fixed:
+                            seed_barray = seed_fixed
+                            seed = int.from_bytes(seed_barray, "little")
+                        else:
+                            ktp.key_len = key_bytes
+                            random_number = ktp.next_key()
+                            ktp.key_len = seed_bytes
+                            seed_barray_int = C_int + \
+                                int.from_bytes(random_number, byteorder='little')
+                            seed_barray = seed_barray_int.to_bytes(seed_bytes, byteorder='little')
+                            seed = seed_barray_int
                     else:
-                        seed_barray = ktp.next_key()
-                        seed = int.from_bytes(seed_barray, "little")
+                        if sample_fixed:
+                            seed_barray = seed_fixed
+                            seed = int.from_bytes(seed_barray, "little")
+                        else:
+                            seed_barray = ktp.next_key()
+                            seed = int.from_bytes(seed_barray, "little")
 
                     if capture_cfg["masks_off"] is True:
                         mask_barray = bytearray(

--- a/cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1_ecdsa.bit
+++ b/cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1_ecdsa.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:39956f9015c1964cd7365e543392f2ab0032ffd2490a1668da952e5eb25d25d3
+oid sha256:286f8ab9e2e77c665fc5bcddb530695c9397ed050219e93e0fc4de491d7fb756
 size 15878032

--- a/cw/objs/otbn_vertical_serial_fpga_cw310.bin
+++ b/cw/objs/otbn_vertical_serial_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d2a29c5a37c9ef5fb01242017791d5441322f98ddf208b2c4d89fbfa2a538247
-size 51168
+oid sha256:9b7a700f7509d4a83175f8c20b41f0e537e4b9146ca2116ad0d6aefc1a6d72b8
+size 45384


### PR DESCRIPTION
This PR has two commits.

The first commit adds the code for batch-capture OTBN-vertical keygen in the KEY mode.
The second commit updates the bitstream and the binary.
The binary is compiled from [OT PR 18027](https://github.com/lowRISC/opentitan/pull/18027)