### PR TITLE
[kmac, sha3] Update bitstream and binaries to lowRISC/OpenTitan@dd8b709

### DIFF
--- a/cw/capture_kmac_cw310.yaml
+++ b/cw/capture_kmac_cw310.yaml
@@ -30,11 +30,11 @@ capture:
   #lfsr_seed: 0
   # w/ DOM
   lfsr_seed: 0xdeadbeef
-  scope_gain: 27
+  batch_prng_seed: 0
+  scope_gain: 26
   num_traces: 5000
   project_name: projects/opentitan_simple_kmac
   waverunner_ip: 192.168.1.228
-  batch_prng_seed: 0
 plot_capture:
   show: true
   num_traces: 100

--- a/cw/capture_sha3_cw310.yaml
+++ b/cw/capture_sha3_cw310.yaml
@@ -8,24 +8,26 @@ capture:
   key_len_bytes: 16
   plain_text_len_bytes: 16
   output_len_bytes: 32
+  # Switch the masking on or off. When off, messages aren't masked upon loading
+  # into the SHA3 core and the PRNG isn't advanced during SHA3 processing.
+  # Works for SHA3 only. Doesn't work when processing key material.
   masks_off: false
-  # Samples per trace - We oversample by 20x
-  num_samples: 3500
-  # Offest in samples
-  offset: 0
-  # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
-  # For unprotected implemetation, lfsr_seed should be set to 0. This will
-  # effectively switch off the masking. For masked implementation, any seed
-  # other than 0 should be used.
-  # w/o DOM
-  #lfsr_seed: 0
-  # w/ DOM
+  # Samples per trace - We oversample by 20x and SHA3 with DOM is doing 120
+  # cycles (24 for loading and padding, 96 for processing) with 320 delay
+  # cycles between loading the plaintext and adding the padding. The plaintext
+  # loading and the delay cycles can be ignored.
+  num_samples: 2500
+  offset: 6400
+  # w/o ignoring the plaintext loading and delay
+  #num_samples: 8900
+  #offset: 0
+  # 32-bit LFSR seed - Currently not used by the target for SHA3 captures.
   lfsr_seed: 0xdeadbeef
-  scope_gain: 26
+  batch_prng_seed: 0
+  scope_gain: 27
   num_traces: 5000
   project_name: projects/opentitan_simple_sha3
   waverunner_ip: 192.168.1.228
-  batch_prng_seed: 0
 plot_capture:
   show: true
   num_traces: 100

--- a/cw/capture_sha3_masks_off_cw310.yaml
+++ b/cw/capture_sha3_masks_off_cw310.yaml
@@ -8,24 +8,26 @@ capture:
   key_len_bytes: 16
   plain_text_len_bytes: 16
   output_len_bytes: 32
-  masks_off: true 
-  # Samples per trace - We oversample by 20x 
-  num_samples: 5200
-  # Offest in samples
-  offset: 0
-  # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
-  # For unprotected implemetation, lfsr_seed should be set to 0. This will
-  # effectively switch off the masking. For masked implementation, any seed
-  # other than 0 should be used.
-  # w/o DOM
-  #lfsr_seed: 0
-  # w/ DOM
+  # Switch the masking on or off. When off, messages aren't masked upon loading
+  # into the SHA3 core and the PRNG isn't advanced during SHA3 processing.
+  # Works for SHA3 only. Doesn't work when processing key material.
+  masks_off: true
+  # Samples per trace - We oversample by 20x and SHA3 with DOM is doing 120
+  # cycles (24 for loading and padding, 96 for processing) with 320 delay
+  # cycles between loading the plaintext and adding the padding. The plaintext
+  # loading and the delay cycles can be ignored.
+  num_samples: 2500
+  offset: 6400
+  # w/o ignoring the plaintext loading and delay
+  #num_samples: 8900
+  #offset: 0
+  # 32-bit LFSR seed - Currently not used by the target for SHA3 captures.
   lfsr_seed: 0xdeadbeef
+  batch_prng_seed: 0
   scope_gain: 27
   num_traces: 5000
-  project_name: projects/opentitan_simple_sha3_masks_off
+  project_name: projects/opentitan_simple_sha3
   waverunner_ip: 192.168.1.228
-  batch_prng_seed: 0
 plot_capture:
   show: true
   num_traces: 100

--- a/cw/objs/kmac_serial_fpga_cw310.bin
+++ b/cw/objs/kmac_serial_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3a8ec3669cc19894208af6f26de07731b17038a109efa48a79593ea439be003
-size 19116
+oid sha256:cc76751fe856db82f0f176ae5487cc9a0d1f9b717c1402e8360ea50b101bde5c
+size 31344

--- a/cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
+++ b/cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92f5e533e444be87cf349b38f9b0f8393c89830bcc89e5741ce7f8694e4202df
+oid sha256:2570d4d52e36ffee46c91d42e022638cada8844ab6aeaf6b8c99c65816cf3086
 size 15878032

--- a/cw/objs/sha3_serial_fpga_cw310.bin
+++ b/cw/objs/sha3_serial_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e7b3bf83395b3b7d80b47c27976445b8d0972f02a6b100ac4263a6ce3cea78d0
-size 21316
+oid sha256:9ca47655212265ac6f9e7c360b1a08f6bba0ecba74e444787a636b5517df3a47
+size 31416


### PR DESCRIPTION
To save logic resources and allow enabling KMAC masking, the following hardware changes have been implemented:
- ECC and scrambling have been disabled for flash_ctrl.
- AES masking has been disabled.
- OTBN has been stubbed out.

The bitstream and binaries have been generated from https://github.com/vogelpi/opentitan/tree/ot-sca_2023-07-15_dd8b709_cw310