### PR TITLE
[tvla] clean up

### DIFF
--- a/cw/tvla.py
+++ b/cw/tvla.py
@@ -424,6 +424,9 @@ def run_tvla(ctx: typer.Context):
         save_to_disk_trace = False
         save_to_disk_leakage = False
 
+    # By default, the first two moments are computed. This can be modified to any order.
+    num_orders = 2
+
     if cfg["input_histogram_file"] is not None:
         # Load previously generated histograms.
         histograms_file = np.load(cfg["input_histogram_file"])
@@ -443,9 +446,6 @@ def run_tvla(ctx: typer.Context):
 
         # The number of samples processed by each parallel job at a time.
         sample_step_ttest = num_samples // num_jobs
-
-        # By default, the first two moments are computed. This can be modified to any order.
-        num_orders = 2
 
         x_axis = np.arange(trace_resolution)
 
@@ -686,7 +686,7 @@ def run_tvla(ctx: typer.Context):
             project.close(save=False)
 
             if general_test is False:
-                # Compute or load prevsiously computed leakage model.
+                # Compute or load previously computed leakage model.
                 if cfg["leakage_file"] is None:
                     # leakage models: HAMMING_WEIGHT (default), HAMMING_DISTANCE
                     log.info("Computing Leakage")
@@ -763,9 +763,6 @@ def run_tvla(ctx: typer.Context):
             # The number of samples processed by each parallel job at a time.
             sample_step_ttest = num_samples // num_jobs
 
-            # By default, the first two moments are computed. This can be modified to any order.
-            num_orders = 2
-
             x_axis = np.arange(trace_resolution)
 
             # Compute statistics.
@@ -808,7 +805,7 @@ def run_tvla(ctx: typer.Context):
         num_samples = ttest_step.shape[3]
         num_steps = ttest_step.shape[4]
         trace_end_vec = ttest_step_file['trace_end_vec']
-        # The rounds and bytes of interests must be available in the previously generated t-test
+        # The rounds and bytes of interest must be available in the previously generated t-test
         # results. In addition, we may need to translate indices to extract the right portion of
         # of the loaded results.
         rnd_ext = np.zeros((num_rnds), dtype=np.uint8)

--- a/cw/tvla_cfg_aes_specific_byte0_rnd0.yaml
+++ b/cw/tvla_cfg_aes_specific_byte0_rnd0.yaml
@@ -4,6 +4,7 @@ trace_start: null
 trace_end: null
 leakage_file: null
 save_to_disk: null
+save_to_disk_ttest: null
 round_select: 0
 byte_select: 0
 input_histogram_file: null

--- a/cw/tvla_cfg_aes_specific_byte0_rnd0.yaml
+++ b/cw/tvla_cfg_aes_specific_byte0_rnd0.yaml
@@ -6,8 +6,8 @@ leakage_file: null
 save_to_disk: null
 round_select: 0
 byte_select: 0
-input_file: null
-output_file: null
+input_histogram_file: null
+output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: true

--- a/cw/tvla_cfg_kmac.yaml
+++ b/cw/tvla_cfg_kmac.yaml
@@ -4,6 +4,7 @@ trace_start: null
 trace_end: null
 leakage_file: null
 save_to_disk: null
+save_to_disk_ttest: null
 round_select: null
 byte_select: null
 input_histogram_file: null

--- a/cw/tvla_cfg_kmac.yaml
+++ b/cw/tvla_cfg_kmac.yaml
@@ -6,8 +6,8 @@ leakage_file: null
 save_to_disk: null
 round_select: null
 byte_select: null
-input_file: null
-output_file: null
+input_histogram_file: null
+output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: true

--- a/cw/tvla_cfg_otbn_keygen.yaml
+++ b/cw/tvla_cfg_otbn_keygen.yaml
@@ -4,6 +4,7 @@ trace_start: null
 trace_end: null
 leakage_file: null
 save_to_disk: null
+save_to_disk_ttest: null
 round_select: null
 byte_select: null
 input_histogram_file: null

--- a/cw/tvla_cfg_otbn_keygen.yaml
+++ b/cw/tvla_cfg_otbn_keygen.yaml
@@ -6,8 +6,8 @@ leakage_file: null
 save_to_disk: null
 round_select: null
 byte_select: null
-input_file: null
-output_file: null
+input_histogram_file: null
+output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: true

--- a/cw/tvla_cfg_otbn_modinv.yaml
+++ b/cw/tvla_cfg_otbn_modinv.yaml
@@ -4,6 +4,7 @@ trace_start: null
 trace_end: null
 leakage_file: null
 save_to_disk: null
+save_to_disk_ttest: null
 round_select: null
 byte_select: null
 input_histogram_file: null

--- a/cw/tvla_cfg_otbn_modinv.yaml
+++ b/cw/tvla_cfg_otbn_modinv.yaml
@@ -6,8 +6,8 @@ leakage_file: null
 save_to_disk: null
 round_select: null
 byte_select: null
-input_file: null
-output_file: null
+input_histogram_file: null
+output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: true

--- a/cw/tvla_cfg_sha3.yaml
+++ b/cw/tvla_cfg_sha3.yaml
@@ -4,6 +4,7 @@ trace_start: null
 trace_end: null
 leakage_file: null
 save_to_disk: null
+save_to_disk_ttest: null
 round_select: null
 byte_select: null
 input_histogram_file: null

--- a/cw/tvla_cfg_sha3.yaml
+++ b/cw/tvla_cfg_sha3.yaml
@@ -6,8 +6,8 @@ leakage_file: null
 save_to_disk: null
 round_select: null
 byte_select: null
-input_file: null
-output_file: null
+input_histogram_file: null
+output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: true

--- a/cw/tvla_cfg_sha3_masks_off.yaml
+++ b/cw/tvla_cfg_sha3_masks_off.yaml
@@ -4,6 +4,7 @@ trace_start: null
 trace_end: null
 leakage_file: null
 save_to_disk: null
+save_to_disk_ttest: null
 round_select: null
 byte_select: null
 input_histogram_file: null

--- a/cw/tvla_cfg_sha3_masks_off.yaml
+++ b/cw/tvla_cfg_sha3_masks_off.yaml
@@ -6,8 +6,8 @@ leakage_file: null
 save_to_disk: null
 round_select: null
 byte_select: null
-input_file: null
-output_file: null
+input_histogram_file: null
+output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: true

--- a/cw/tvla_cfg_template.yaml
+++ b/cw/tvla_cfg_template.yaml
@@ -6,13 +6,13 @@ leakage_file: null
 save_to_disk: null
 round_select: null
 byte_select: null
-input_file: null
-output_file: null
+input_histogram_file: null
+output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: false
 general_test: true
 mode: aes
 # Only enabled for otbn mode.
-sample_start: null 
+sample_start: null
 num_samples : null

--- a/cw/tvla_cfg_template.yaml
+++ b/cw/tvla_cfg_template.yaml
@@ -4,6 +4,7 @@ trace_start: null
 trace_end: null
 leakage_file: null
 save_to_disk: null
+save_to_disk_ttest: null
 round_select: null
 byte_select: null
 input_histogram_file: null

--- a/test/tvla_test.py
+++ b/test/tvla_test.py
@@ -38,7 +38,7 @@ def test_general_nonleaking_project():
 
 def test_general_leaking_histogram():
     hist_path = TestDataPath('tvla_general/kmac_hist_leaking.npz')
-    tvla = TvlaCmd(Args(['--input-file', str(hist_path),
+    tvla = TvlaCmd(Args(['--input-histogram-file', str(hist_path),
                         '--mode', 'kmac', 'run-tvla'])).run()
     assert ttest_significant(np.load('tmp/ttest.npy')), (
            f"{tvla} did not find significant leakage, which is unexpected")
@@ -46,7 +46,7 @@ def test_general_leaking_histogram():
 
 def test_general_nonleaking_histogram():
     hist_path = TestDataPath('tvla_general/kmac_hist_nonleaking.npz')
-    tvla = TvlaCmd(Args(['--input-file', str(hist_path),
+    tvla = TvlaCmd(Args(['--input-histogram-file', str(hist_path),
                         '--mode', 'kmac', 'run-tvla'])).run()
     assert not ttest_significant(np.load('tmp/ttest.npy')), (
            f"{tvla} did find significant leakage, which is unexpected")

--- a/test/tvla_test.py
+++ b/test/tvla_test.py
@@ -31,7 +31,7 @@ def ttest_significant(ttest_trace) -> bool:
 def test_general_nonleaking_project():
     project_path = TestDataPath('tvla_general/ci_opentitan_simple_kmac.cwp')
     tvla = TvlaCmd(Args(['--project-file', str(project_path),
-                        '--mode', 'kmac', 'run-tvla'])).run()
+                        '--mode', 'kmac', '--save-to-disk-ttest', 'run-tvla'])).run()
     assert not ttest_significant(np.load('tmp/ttest.npy')), (
            f"{tvla} did find significant leakage, which is unexpected")
 
@@ -39,7 +39,7 @@ def test_general_nonleaking_project():
 def test_general_leaking_histogram():
     hist_path = TestDataPath('tvla_general/kmac_hist_leaking.npz')
     tvla = TvlaCmd(Args(['--input-histogram-file', str(hist_path),
-                        '--mode', 'kmac', 'run-tvla'])).run()
+                        '--mode', 'kmac', '--save-to-disk-ttest', 'run-tvla'])).run()
     assert ttest_significant(np.load('tmp/ttest.npy')), (
            f"{tvla} did not find significant leakage, which is unexpected")
 
@@ -47,6 +47,6 @@ def test_general_leaking_histogram():
 def test_general_nonleaking_histogram():
     hist_path = TestDataPath('tvla_general/kmac_hist_nonleaking.npz')
     tvla = TvlaCmd(Args(['--input-histogram-file', str(hist_path),
-                        '--mode', 'kmac', 'run-tvla'])).run()
+                        '--mode', 'kmac', '--save-to-disk-ttest', 'run-tvla'])).run()
     assert not ttest_significant(np.load('tmp/ttest.npy')), (
            f"{tvla} did find significant leakage, which is unexpected")


### PR DESCRIPTION
This PR cleans up tvla code:
1. Renames histogram related arguments
2. Fixes typos and code duplication
3. Refactors code related to saving t-test results