### PR TITLE
[ci] Test stepping function of tvla in CI

### DIFF
--- a/cw/tvla.py
+++ b/cw/tvla.py
@@ -817,12 +817,12 @@ def run_tvla(ctx: typer.Context):
     if save_to_disk_ttest:
         if num_steps > 1:
             log.info("Saving T-test Step")
-            np.savez('tmp/ttest-step.npy',
-                     ttest_step=ttest_step,
-                     trace_end_vec=trace_end_vec,
-                     rnd_list=rnd_list,
-                     byte_list=byte_list,
-                     single_trace=traces[1])
+            np.savez_compressed('tmp/ttest-step.npy',
+                                ttest_step=ttest_step,
+                                trace_end_vec=trace_end_vec,
+                                rnd_list=rnd_list,
+                                byte_list=byte_list,
+                                single_trace=traces[1])
         else:
             log.info("Saving T-test")
             np.save('tmp/ttest.npy', ttest_trace)

--- a/test/data/tvla_general/ttest-step-golden.npy.npz
+++ b/test/data/tvla_general/ttest-step-golden.npy.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a8a5464d66ea197c1677ad6d049fc155a453ede90d0853c3a05dc3107d7ba2e
+size 456902


### PR DESCRIPTION
This PR modifies `test_general_nonleaking_project()` to run TVLA with `--number-of-steps 10` and compare the produced result with the checked-in numerical value, rather than just checking for leakage.

Partially addresses #96