### PR TITLE
[capture] Remove redundant key write

### DIFF
--- a/cw/capture.py
+++ b/cw/capture.py
@@ -892,7 +892,6 @@ def capture_kmac_random(ot, ktp):
     """
     key, _ = ktp.next()
     tqdm.write(f'Using key: {binascii.b2a_hex(bytes(key))}')
-    ot.target.simpleserial_write('k', key)
     while True:
         _, text = ktp.next()
         ret = cw.capture_trace(ot.scope, ot.target, text, key, ack=False, as_int=True)


### PR DESCRIPTION
Writing key at the begining of `capture_kmac_random()` is redundant because `cw.capture_trace()` will send the key on every run.