### PR TITLE
[docker/podman] Fix user permissions

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -152,7 +152,7 @@ The
 [Dockerfile](https://github.com/lowRISC/ot-sca/blob/master/util/docker/Dockerfile)
 in this repository can be used to build a ready-to-use image with all the
 dependencies installed. To build the image:
-1. If not already installed, install Podman following the instructions
+1. If not already installed, install Podman and containers-storage following the instructions
 [here](https://podman.io/getting-started/installation), and
 2. Build the container image using
 [build\_image.sh](https://github.com/lowRISC/ot-sca/blob/master/util/docker/build_image.sh):

--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -32,8 +32,7 @@ RUN apt-get update && \
         ca-certificates \
         screen \
         locales \
-        tzdata \
-        util-linux && \
+        tzdata && \
     curl -fsSL https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | DEBIAN_FRONTEND="noninteractive" bash && \
     apt-get update && \
     apt-get install --no-install-recommends -y git-lfs
@@ -83,6 +82,6 @@ RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 # Entrypoint
 COPY util/docker/docker_entrypoint.sh /docker_entrypoint.sh
-RUN echo "exec /docker_entrypoint.sh '${USER_NAME}' '${MOUNT_DIR}'" > /docker_entrypoint_wrapper.sh
+RUN echo "exec /docker_entrypoint.sh" > /docker_entrypoint_wrapper.sh
 RUN chmod +x /docker_entrypoint.sh /docker_entrypoint_wrapper.sh
 ENTRYPOINT /docker_entrypoint_wrapper.sh

--- a/util/docker/docker_entrypoint.sh
+++ b/util/docker/docker_entrypoint.sh
@@ -4,45 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Entrypoint for OpenTitan SCA/FI image. This script:
-# - Creates a new non-privileged user with the same UID and GID as the owner of
-#   the host directory to avoid permission issues,
-# - Adds this user to plugdev and dialout groups to able to access
-#   chipwhisperer devices,
-# - Drops root privileges by switching to the newly created user, and
 # - Replaces the current process with a new shell.
 
-# We expect only two variables.
-if [[ "$#" -ne 2 ]]; then
-  echo "Unexpected number of parameters: $#" >&2
-  exit 1
-fi
-
-readonly USER_NAME="$1"
-readonly MOUNT_DIR="$2"
 readonly SHELL='/bin/bash'
 
-# Create a user with the same UID and GID as the owner of the mount.
-# Note: The user is also added to plugdev and dialout to be able talk to
-# chipwhisperer USB devices. IDs of these groups must match those of the
-# host system, which typically is the case.
-HOST_UID="$(stat -c '%u' "${MOUNT_DIR}")"
-readonly HOST_UID
-HOST_GID="$(stat -c '%g' "${MOUNT_DIR}")"
-readonly HOST_GID 
-echo "Creating user '${USER_NAME}' with UID=${HOST_UID}, GID=${HOST_GID}."
-groupadd -g "${HOST_GID}" "${USER_NAME}"
-useradd -u "${HOST_UID}" -g "${HOST_GID}" -m -s "${SHELL}" "${USER_NAME}"
-
-# Install git lfs
-runuser "${USER_NAME}" -c 'git lfs install' > /dev/null
-
-# Workaround for setpriv: libcap-ng is too old for "-all" caps argument.
-# Instead, create a list of all capabilities supported by the kernel.
-CAP_PREFIX="-cap_"
-CAPS="${CAP_PREFIX}$(seq -s ",${CAP_PREFIX}" 0 $(cat /proc/sys/kernel/cap_last_cap))"
-
-# Cleanup, drop privileges, and replace the current process with a new shell.
-rm /docker_entrypoint.sh /docker_entrypoint_wrapper.sh
-HOME_DIR="$(getent passwd "${USER_NAME}" | cut -d : -f 6)"
-readonly HOME_DIR
-HOME="${HOME_DIR}" exec setpriv --reuid="${HOST_UID}" --regid="${HOST_GID}" --inh-caps=${CAPS} --init-group "${SHELL}"
+# Switch to shell
+exec "${SHELL}"

--- a/util/docker/run_container.sh
+++ b/util/docker/run_container.sh
@@ -58,6 +58,7 @@ if [[ -z "${HOST_WORK_DIR}" ]] || [[ -z "${SHM_SIZE}" ]] || [[ ${#DEVICES[@]} -e
 fi
 
 podman run --rm -it \
+    --userns=keep-id \
     --shm-size "${SHM_SIZE}" \
     -v "${HOST_WORK_DIR}":"${CONTAINER_WORK_DIR}" \
     -w "${CONTAINER_WORK_DIR}" \


### PR DESCRIPTION
Before this commit, the container started as root with the following warnings:
```
Creating user 'ot' with UID=0, GID=0. 
groupadd: GID '0' already exists 
useradd: UID 0 is not unique
runuser: user ot does not exist
root@ot-sca:/repo#
```
With podman 4.3, the option --userns=keep-id when running the container forwards the UID & GID.
Hence, no manual permission management is needed anymore.
Now, the user inside the container matches the user starting it.