### PR TITLE
[tvla] Enable filtering

### DIFF
--- a/cw/tvla.py
+++ b/cw/tvla.py
@@ -397,7 +397,7 @@ def run_tvla(ctx: typer.Context):
 
                 if i_step == 0:
                     # Keep a single trace to create the figures.
-                    single_trace = traces[1]
+                    single_trace = traces[traces_to_use[0]]
 
                 if save_to_disk_trace:
                     log.info("Saving Traces")

--- a/cw/tvla.py
+++ b/cw/tvla.py
@@ -372,28 +372,23 @@ def run_tvla(ctx: typer.Context):
                                                          trace_start] + 0.5) * trace_resolution
                     traces = traces.astype('uint16')
 
-                if general_test is False:
-                    # Filter out noisy traces.
-                    log.info("Filtering Traces")
+                # Filter out noisy traces.
+                log.info("Filtering Traces")
 
-                    # Get the mean and standard deviation.
-                    mean = traces.mean(axis=0)
-                    std = traces.std(axis=0)
+                # Get the mean and standard deviation.
+                mean = traces.mean(axis=0)
+                std = traces.std(axis=0)
 
-                    # Define upper and lower limits.
-                    max_trace = mean + num_sigmas * std
-                    min_trace = mean - num_sigmas * std
+                # Define upper and lower limits.
+                max_trace = mean + num_sigmas * std
+                min_trace = mean - num_sigmas * std
 
-                    # Filtering of converted traces (len = num_samples). traces_to_use itself can be
-                    # used to index the entire project file (len >= num_samples).
-                    traces_to_use = np.zeros(len(project.waves), dtype=bool)
-                    traces_to_use[trace_start:trace_end + 1] = np.all((traces >= min_trace) &
-                                                                      (traces <= max_trace), axis=1)
-                    traces = traces[traces_to_use[trace_start:trace_end + 1]]
-                else:
-                    # For now, don't perform any filtering when doing general fixed-vs-random TVLA.
-                    traces_to_use = np.zeros(len(project.waves), dtype=bool)
-                    traces_to_use[trace_start:trace_end + 1] = True
+                # Filtering of converted traces (len = num_samples). traces_to_use itself can be
+                # used to index the entire project file (len >= num_samples).
+                traces_to_use = np.zeros(len(project.waves), dtype=bool)
+                traces_to_use[trace_start:trace_end + 1] = np.all((traces >= min_trace) &
+                                                                  (traces <= max_trace), axis=1)
+                traces = traces[traces_to_use[trace_start:trace_end + 1]]
 
                 if i_step == 0:
                     # Keep a single trace to create the figures.

--- a/test/data/tvla_general/ttest-step-golden-aes.npy.npz
+++ b/test/data/tvla_general/ttest-step-golden-aes.npy.npz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:197ee6315dd31ce1155e0a59a6404b786b9e9d1f1b9a126101ea00b712e2de84
-size 187056
+oid sha256:a3d093bbe7ed6a87bd19860c0f2b2fa6b577170c0e66b0d839836e5d4f18c9c9
+size 185790


### PR DESCRIPTION
At the moment trace filtering is enabled only for aes-specific tvla. This PR enables it for general analysis as well.
