### PR TITLE
[cw] Update CW Python dependency

### DIFF
--- a/cw/util/device.py
+++ b/cw/util/device.py
@@ -152,6 +152,10 @@ class OpenTitan(object):
         scope.io.tio2 = "serial_rx"
         scope.io.hs2 = "disabled"
 
+        # Make sure that clkgen_locked is true.
+        if husky:
+            scope.clock.clkgen_src = 'extclk'
+
         # TODO: Need to update error handling.
         if not husky:
             scope.clock.reset_adc()

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -27,7 +27,7 @@ joblib
 # Development version of ChipWhisperer toolchain with latest features and
 # bug fixes - Needs to be installed in editable mode. We fix the version
 # for improved stability and manually update if necessary.
--e git+https://github.com/newaetech/chipwhisperer.git@c5181a87111d3aabab42d83b10dbc368140b43ef#egg=chipwhisperer
+-e git+https://github.com/newaetech/chipwhisperer.git@3eace1719daf43d4f0965c1790c2c8a9e8b2f690#egg=chipwhisperer
 
 # Linters
 -r python-requirements-lint.txt


### PR DESCRIPTION
This PR updates the ChipWhisperer Python dependency to the latest available CW version.

For Husky, we need to make sure that the clkgen is locked after setting the clock.