### PR TITLE
[capture] Fix project export

### DIFF
--- a/cw/capture.py
+++ b/cw/capture.py
@@ -208,7 +208,7 @@ def capture_loop(trace_gen, ot, capture_cfg, device_cfg):
 def capture_end(cfg):
     if cfg["plot_capture"]["show"]:
         plot_results(cfg["plot_capture"], cfg["capture"]["project_name"])
-    if cfg["capture"]["project_export"]:
+    if "project_export" in cfg["capture"] and cfg["capture"]["project_export"]:
         project = cw.open_project(cfg["capture"]["project_name"])
         project.export(cfg["capture"]["project_export_filename"])
         project.close(save=False)


### PR DESCRIPTION
As not all config files yet contain the export keyword, this PR adds code that first checks whether this config entry exists.