### PR TITLE
[tvla] Fix TVLA single trace

### DIFF
--- a/cw/tvla.py
+++ b/cw/tvla.py
@@ -392,7 +392,7 @@ def run_tvla(ctx: typer.Context):
 
                 if i_step == 0:
                     # Keep a single trace to create the figures.
-                    single_trace = traces[traces_to_use[0]]
+                    single_trace = traces[0]
 
                 if save_to_disk_trace:
                     log.info("Saving Traces")


### PR DESCRIPTION
Currently, TVLA is failing with:
`ValueError: x and y must have same first dimension, but have shapes` AFAIU, traces_to_use is stored into variable traces in Line 391. Hence, in Line 395, it should be enough to just use traces[0], as this list only contains filtered traces.

@vrozic , could you please have a look?