### PR TITLE
[WIP][ci] Make sure the current CI requests a CW310

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -7,7 +7,9 @@ jobs:
 - job: sca_capture
   displayName: "Capture SCA traces"
   timeoutInMinutes: 30
-  pool: FPGA SCA
+  pool:
+    name: FPGA SCA
+    demands: BOARD -equals cw310
   steps:
   - checkout: self
   - bash: |


### PR DESCRIPTION
This is necessary to ensure that adding the CW305 will not mess with the existing pipelines that assumes a CW310