### PR TITLE
[ci] Add filter_traces to CI job

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -76,5 +76,5 @@ jobs:
   - bash: |
       set -e
       cd cw
-      ./capture.py --cfg-file capture_aes_cw305.yaml capture aes-random-batch --num-traces 10000 --force-program-bitstream
+      ./capture.py --cfg-file capture_aes_cw305.yaml capture aes-random-batch --num-traces 1000 --force-program-bitstream
     displayName: "Capture traces"

--- a/ci/cfg/ci_tvla_cfg_aes_specific_byte0_rnd0.yaml
+++ b/ci/cfg/ci_tvla_cfg_aes_specific_byte0_rnd0.yaml
@@ -14,3 +14,4 @@ ttest_step_file: null
 plot_figures: true
 general_test: false
 mode: aes
+filter_traces: true

--- a/ci/ci_check_tvla_aes.sh
+++ b/ci/ci_check_tvla_aes.sh
@@ -11,7 +11,7 @@ mkdir -p tmp
 MODE="aes"
 BOARD=cw310
 declare -A aes_test_list
-aes_test_list["aes-random"]=100
+aes_test_list["aes-random"]=5000
 
 ARGS="--force-program-bitstream"
 for test in ${!aes_test_list[@]}; do


### PR DESCRIPTION
Add filter_traces to CI job cfg and increase number of trace captures to 5000 to get consistent TVLA results.