### PR TITLE
[capture] Specify offset in target clk cycles

### DIFF
--- a/ci/cfg/ci_capture_aes_cw310.yaml
+++ b/ci/cfg/ci_capture_aes_cw310.yaml
@@ -2,20 +2,25 @@ device:
   fpga_bitstream: ../cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit
   force_program_bitstream: True
   fw_bin: ../cw/objs/aes_serial_fpga_cw310.bin
+  # The clock frequency of the target block is equal to
+  # pll_frequency * target_clk_mult. pll_frequency is controllable via
+  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
+  # bitstream.
   pll_frequency: 100000000
+  target_clk_mult: 0.1
   baudrate: 115200
 capture:
   # Only AES-128 ECB is supported at this moment.
   key_len_bytes: 16
   plain_text_len_bytes: 16
   output_len_bytes: 16
-  # Samples per trace - We oversample by 20x and AES w/ DOM is doing
+  # Number of target clock cycles per trace - AES w/ DOM is doing
   # ~56/72 cycles per encryption (AES-128/256).
-  num_samples: 1200
-  # Offest in samples - The AES idle signal becomes visible 1 target clock
-  # cycle later (20 samples) and there are 2 synchronization stages at 100 MHz
-  # at the top level (4 samples).
-  offset: -40
+  num_cycles: 60
+  # Offset in target clock cycles - The AES idle signal becomes visible
+  # 1 target clock cycle later and there are 2 synchronization stages at
+  # 100 MHz at the top level.
+  offset_cycles: -2
   # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
   # To switch off the masking, 0 must be used as LFSR seed.
   lfsr_seed: 0xdeadbeef

--- a/ci/cfg/ci_capture_kmac_cw310.yaml
+++ b/ci/cfg/ci_capture_kmac_cw310.yaml
@@ -2,26 +2,32 @@ device:
   fpga_bitstream: ../cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: ../cw/objs/kmac_serial_fpga_cw310.bin
+  # The clock frequency of the target block is equal to
+  # pll_frequency * target_clk_mult. pll_frequency is controllable via
+  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
+  # bitstream.
   pll_frequency: 100000000
+  target_clk_mult: 0.1
   baudrate: 115200
 capture:
   key_len_bytes: 16
   plain_text_len_bytes: 16
   output_len_bytes: 32
-  # Samples per trace - We oversample by 20x and KMAC is doing 24 or 96 cycles
+  # Number of target clock cycles per trace - KMAC is doing 24 or 96 cycles
   # for the key absorb w/o or w/ DOM, respectively, as well as 23 cycles for
   # XORing the key into the state.
   # w/o DOM
-  #num_samples: 1600
+  #num_cycles: 80
   # w/ DOM
-  num_samples: 3200
-  # Offest in samples - During the first activity block, KMAC just absorbs the
-  # fixed prefix (23 cycles XORing + 24 or 96 cycles absorbing w/o or w/ DOM,
-  # respectively). This first activity block can be skipped.
+  num_cycles: 160
+  # Offset in target clock cycles - During the first activity block, KMAC
+  # just absorbs the fixed prefix (23 cycles XORing + 24 or 96 cycles
+  # absorbing w/o or w/ DOM, respectively). This first activity block can be
+  # skipped
   # w/o DOM
-  #offset: 860
+  #offset_cyles: 43
   # w/ DOM
-  offset: 2300
+  offset_cycles: 115
   # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
   # For unprotected implemetation, lfsr_seed should be set to 0. This will
   # effectively switch off the masking. For masked implementation, any seed

--- a/ci/cfg/ci_capture_otbn_vertical_keygen.yaml
+++ b/ci/cfg/ci_capture_otbn_vertical_keygen.yaml
@@ -2,9 +2,13 @@ device:
   fpga_bitstream: ../cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1_ecdsa.bit
   force_program_bitstream: False
   fw_bin: ../cw/objs/otbn_vertical_serial_fpga_cw310.bin
-  # Target operating frequency
+  # The clock frequency of the target block is equal to
+  # pll_frequency * target_clk_mult. pll_frequency is controllable via
+  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
+  # bitstream.
   # For non-batch mode max. 91 MHz, otherwise serial communication fails
   pll_frequency: 91000000
+  target_clk_mult: 0.1
   baudrate: 115200
 capture:
   # Currently, 'p256' is the only supported curve.
@@ -23,11 +27,9 @@ capture:
   masks_off: false
   # Output length (most likely unused).
   output_len_bytes: 40
-  # Samples per trace
   # Fifo Size is 131070 = max num samples to avoid multiple runs per trace
-  num_samples: 4000
-  # Offset in samples
-  offset: 0
+  num_cycles: 200
+  offset_cycles: 0
   # scope gain in db
   scope_gain: 24
   num_traces: 50000

--- a/ci/cfg/ci_capture_otbn_vertical_modinv.yaml
+++ b/ci/cfg/ci_capture_otbn_vertical_modinv.yaml
@@ -2,9 +2,13 @@ device:
   fpga_bitstream: ../cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1_ecdsa.bit
   force_program_bitstream: False
   fw_bin: ../cw/objs/otbn_vertical_serial_fpga_cw310.bin
-  # Target operating frequency
+  # The clock frequency of the target block is equal to
+  # pll_frequency * target_clk_mult. pll_frequency is controllable via
+  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
+  # bitstream.
   # For non-batch mode max. 91 MHz, otherwise serial communication fails
   pll_frequency: 100000000
+  target_clk_mult: 0.1
   baudrate: 115200
 capture:
   # Currently, 'p256' is the only supported curve.
@@ -21,11 +25,9 @@ capture:
   masks_off: false
   # Output length (most likely unused).
   output_len_bytes: 32
-  # Samples per trace
   # Fifo Size is 131070 = max num samples to avoid multiple runs per trace
-  num_samples: 100000
-  # Offset in samples
-  offset: 0
+  num_cycles: 5000
+  offset_cycles: 0
   # scope gain in db
   scope_gain: 22
   num_traces: 50000

--- a/ci/cfg/ci_capture_sha3_cw310.yaml
+++ b/ci/cfg/ci_capture_sha3_cw310.yaml
@@ -2,7 +2,12 @@ device:
   fpga_bitstream: ../cw/objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: ../cw/objs/sha3_serial_fpga_cw310.bin
+  # The clock frequency of the target block is equal to
+  # pll_frequency * target_clk_mult. pll_frequency is controllable via
+  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
+  # bitstream.
   pll_frequency: 100000000
+  target_clk_mult: 0.1
   baudrate: 115200
 capture:
   key_len_bytes: 16
@@ -12,15 +17,15 @@ capture:
   # into the SHA3 core and the PRNG isn't advanced during SHA3 processing.
   # Works for SHA3 only. Doesn't work when processing key material.
   masks_off: false
-  # Samples per trace - We oversample by 20x and SHA3 with DOM is doing 120
+  # Number of target clock cycles per trace - SHA3 with DOM is doing 120
   # cycles (24 for loading and padding, 96 for processing) with 320 delay
   # cycles between loading the plaintext and adding the padding. The plaintext
   # loading and the delay cycles can be ignored.
-  num_samples: 2500
-  offset: 6400
+  num_cycles: 125
+  offset_cycles: 320
   # w/o ignoring the plaintext loading and delay
-  #num_samples: 8900
-  #offset: 0
+  #num_cycles: 445
+  #offset_cycles: 0
   # 32-bit LFSR seed - Currently not used by the target for SHA3 captures.
   lfsr_seed: 0xdeadbeef
   batch_prng_seed: 0

--- a/cw/capture_aes_cw305.yaml
+++ b/cw/capture_aes_cw305.yaml
@@ -2,20 +2,25 @@ device:
   fpga_bitstream: objs/lowrisc_systems_chip_englishbreakfast_cw305_0.1.bit
   force_program_bitstream: False
   fw_bin: objs/aes_serial_fpga_cw305.bin
+  # The clock frequency of the target block is equal to
+  # pll_frequency * target_clk_mult. pll_frequency is controllable via
+  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
+  # bitstream.
   pll_frequency: 100000000
+  target_clk_mult: 0.1
   baudrate: 115200
 capture:
   # Only AES-128 ECB is supported at this moment.
   key_len_bytes: 16
   plain_text_len_bytes: 16
   output_len_bytes: 16
-  # Samples per trace - We oversample by 20x and AES w/ DOM is doing
+  # Number of target clock cycles per trace - AES w/ DOM is doing
   # ~56/72 cycles per encryption (AES-128/256).
-  num_samples: 1200
-  # Offest in samples - The AES idle signal becomes visible 1 target clock
-  # cycle later (20 samples) and there are 2 synchronization stages at 100 MHz
-  # at the top level (4 samples).
-  offset: -40
+  num_cycles: 60
+  # Offset in target clock cycles - The AES idle signal becomes visible
+  # 1 target clock cycle later and there are 2 synchronization stages at
+  # 100 MHz at the top level.
+  offset_cycles: -2
   # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
   # To switch off the masking, 0 must be used as LFSR seed.
   lfsr_seed: 0xdeadbeef

--- a/cw/capture_aes_cw310.yaml
+++ b/cw/capture_aes_cw310.yaml
@@ -2,20 +2,25 @@ device:
   fpga_bitstream: objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit
   force_program_bitstream: False
   fw_bin: objs/aes_serial_fpga_cw310.bin
+  # The clock frequency of the target block is equal to
+  # pll_frequency * target_clk_mult. pll_frequency is controllable via
+  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
+  # bitstream.
   pll_frequency: 100000000
+  target_clk_mult: 0.1
   baudrate: 115200
 capture:
   # Only AES-128 ECB is supported at this moment.
   key_len_bytes: 16
   plain_text_len_bytes: 16
   output_len_bytes: 16
-  # Samples per trace - We oversample by 20x and AES w/ DOM is doing
+  # Number of target clock cycles per trace - AES w/ DOM is doing
   # ~56/72 cycles per encryption (AES-128/256).
-  num_samples: 1200
-  # Offest in samples - The AES idle signal becomes visible 1 target clock
-  # cycle later (20 samples) and there are 2 synchronization stages at 100 MHz
-  # at the top level (4 samples).
-  offset: -40
+  num_cycles: 60
+  # Offset in target clock cycles - The AES idle signal becomes visible
+  # 1 target clock cycle later and there are 2 synchronization stages at
+  # 100 MHz at the top level.
+  offset_cycles: -2
   # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
   # To switch off the masking, 0 must be used as LFSR seed.
   lfsr_seed: 0xdeadbeef

--- a/cw/capture_ecdsa256_cw310.yaml
+++ b/cw/capture_ecdsa256_cw310.yaml
@@ -2,23 +2,28 @@ device:
   fpga_bitstream: objs/lowrisc_systems_chip_earlgrey_cw310_0.1_ecdsa.bit
   force_program_bitstream: True
   fw_bin: objs/ecc256_serial_fpga_cw310.bin
-  # Target operating frequency:
+  # The clock frequency of the target block is equal to
+  # pll_frequency * target_clk_mult. pll_frequency is controllable via
+  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
+  # bitstream.
   # for ecdsa-simple: 25-50MHz (alignment issues above 66MHz)
   # for ecdsa-stream: 15-20MHz (sampling_rate-adc_resolution tradeoff)
   # More details on Husky stream mode can be found in the following links:
   # https://github.com/lowRISC/ot-sca/issues/106#issuecomment-1359530023
   # https://rtfm.newae.com/Capture/ChipWhisperer-Husky/#streaming-mode
-  pll_frequency: 15000000
+  pll_frequency: 20000000
+  target_clk_mult: 0.1
   baudrate: 115200
 capture:
   # Only ECDSA-256 (32) and ECDSA-384 (48) are supported at this moment.
   key_len_bytes: 32
   plain_text_len_bytes: 32
   output_len_bytes: 32
-  # Samples per trace
-  num_samples: 262140
-  # Offset in samples
-  offset: 0
+  # With pll_frequency = 20 MHz and target_clk_mult = 0.1, 2000
+  # target clock cycles correspond to 200000 scope samples on Husky
+  # (100x oversampling).
+  num_cycles: 2000
+  offset_cycles: 0
   # scope gain in db - This may change for each setup,
   # find a value for your setup
   scope_gain: 32.5

--- a/cw/capture_ecdsa384_cw310.yaml
+++ b/cw/capture_ecdsa384_cw310.yaml
@@ -2,20 +2,25 @@ device:
   fpga_bitstream: objs/lowrisc_systems_chip_earlgrey_cw310_0.1_ecdsa.bit
   force_program_bitstream: False
   fw_bin: objs/ecc384_serial_fpga_cw310.bin
-  # Target operating frequency
-  pll_frequency: 22000000
+  # The clock frequency of the target block is equal to
+  # pll_frequency * target_clk_mult. pll_frequency is controllable via
+  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
+  # bitstream.
+  pll_frequency: 20000000
+  target_clk_mult: 0.1
   baudrate: 115200
 capture:
   # Only ECDSA-256 (32) and ECDSA-384 (48) are supported at this moment.
   key_len_bytes: 48
   plain_text_len_bytes: 48
   output_len_bytes: 48
-  # Samples per trace
-  num_samples: 262140
-  # Offset in samples
-  offset: 0
-  # scope gain in db - 13 for non-stream mode, 28 for stream mode
-  scope_gain: 13
+  # With pll_frequency = 20 MHz and target_clk_mult = 0.1, 2000
+  # target clock cycles correspond to 200000 scope samples on Husky
+  # (100x oversampling).
+  num_cycles: 2000
+  offset_cycles: 0
+  # scope gain in db - 13 for non-stream mode, 32.5 for stream mode
+  scope_gain: 32.5
   num_traces: 1
   project_name: projects/opentitan_ecdsa_384
   waverunner_ip: 192.168.1.228

--- a/cw/capture_kmac_cw310.yaml
+++ b/cw/capture_kmac_cw310.yaml
@@ -2,26 +2,32 @@ device:
   fpga_bitstream: objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: objs/kmac_serial_fpga_cw310.bin
+  # The clock frequency of the target block is equal to
+  # pll_frequency * target_clk_mult. pll_frequency is controllable via
+  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
+  # bitstream.
   pll_frequency: 100000000
+  target_clk_mult: 0.1
   baudrate: 115200
 capture:
   key_len_bytes: 16
   plain_text_len_bytes: 16
   output_len_bytes: 32
-  # Samples per trace - We oversample by 20x and KMAC is doing 24 or 96 cycles
+  # Number of target clock cycles per trace - KMAC is doing 24 or 96 cycles
   # for the key absorb w/o or w/ DOM, respectively, as well as 23 cycles for
   # XORing the key into the state.
   # w/o DOM
-  #num_samples: 1600
+  #num_cycles: 80
   # w/ DOM
-  num_samples: 3200
-  # Offest in samples - During the first activity block, KMAC just absorbs the
-  # fixed prefix (23 cycles XORing + 24 or 96 cycles absorbing w/o or w/ DOM,
-  # respectively). This first activity block can be skipped.
+  num_cycles: 160
+  # Offset in target clock cycles - During the first activity block, KMAC
+  # just absorbs the fixed prefix (23 cycles XORing + 24 or 96 cycles
+  # absorbing w/o or w/ DOM, respectively). This first activity block can be
+  # skipped
   # w/o DOM
-  #offset: 860
+  #offset_cyles: 43
   # w/ DOM
-  offset: 2300
+  offset_cycles: 115
   # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
   # For unprotected implemetation, lfsr_seed should be set to 0. This will
   # effectively switch off the masking. For masked implementation, any seed

--- a/cw/capture_otbn_vertical_keygen.yaml
+++ b/cw/capture_otbn_vertical_keygen.yaml
@@ -2,9 +2,13 @@ device:
   fpga_bitstream: objs/lowrisc_systems_chip_earlgrey_cw310_0.1_ecdsa.bit
   force_program_bitstream: False
   fw_bin: objs/otbn_vertical_serial_fpga_cw310.bin
-  # Target operating frequency
+  # The clock frequency of the target block is equal to
+  # pll_frequency * target_clk_mult. pll_frequency is controllable via
+  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
+  # bitstream.
   # For non-batch mode max. 91 MHz, otherwise serial communication fails
   pll_frequency: 91000000
+  target_clk_mult: 0.1
   baudrate: 115200
 capture:
   # Currently, 'p256' is the only supported curve.
@@ -23,11 +27,9 @@ capture:
   masks_off: false
   # Output length (most likely unused).
   output_len_bytes: 40
-  # Samples per trace
   # Fifo Size is 131070 = max num samples to avoid multiple runs per trace
-  num_samples: 4000
-  # Offset in samples
-  offset: 0
+  num_cycles: 200
+  offset_cycles: 0
   # scope gain in db
   scope_gain: 24
   num_traces: 50000

--- a/cw/capture_otbn_vertical_modinv.yaml
+++ b/cw/capture_otbn_vertical_modinv.yaml
@@ -2,9 +2,13 @@ device:
   fpga_bitstream: objs/lowrisc_systems_chip_earlgrey_cw310_0.1_ecdsa.bit
   force_program_bitstream: False
   fw_bin: objs/otbn_vertical_serial_fpga_cw310.bin
-  # Target operating frequency
+  # The clock frequency of the target block is equal to
+  # pll_frequency * target_clk_mult. pll_frequency is controllable via
+  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
+  # bitstream.
   # For non-batch mode max. 91 MHz, otherwise serial communication fails
   pll_frequency: 100000000
+  target_clk_mult: 0.1
   baudrate: 115200
 capture:
   # Currently, 'p256' is the only supported curve.
@@ -21,11 +25,9 @@ capture:
   masks_off: false
   # Output length (most likely unused).
   output_len_bytes: 32
-  # Samples per trace
   # Fifo Size is 131070 = max num samples to avoid multiple runs per trace
-  num_samples: 100000
-  # Offset in samples
-  offset: 0
+  num_cycles: 5000
+  offset_cycles: 0
   # scope gain in db
   scope_gain: 22
   num_traces: 50000

--- a/cw/capture_sha3_cw310.yaml
+++ b/cw/capture_sha3_cw310.yaml
@@ -2,7 +2,12 @@ device:
   fpga_bitstream: objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: objs/sha3_serial_fpga_cw310.bin
+  # The clock frequency of the target block is equal to
+  # pll_frequency * target_clk_mult. pll_frequency is controllable via
+  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
+  # bitstream.
   pll_frequency: 100000000
+  target_clk_mult: 0.1
   baudrate: 115200
 capture:
   key_len_bytes: 16
@@ -12,15 +17,15 @@ capture:
   # into the SHA3 core and the PRNG isn't advanced during SHA3 processing.
   # Works for SHA3 only. Doesn't work when processing key material.
   masks_off: false
-  # Samples per trace - We oversample by 20x and SHA3 with DOM is doing 120
+  # Number of target clock cycles per trace - SHA3 with DOM is doing 120
   # cycles (24 for loading and padding, 96 for processing) with 320 delay
   # cycles between loading the plaintext and adding the padding. The plaintext
   # loading and the delay cycles can be ignored.
-  num_samples: 2500
-  offset: 6400
+  num_cycles: 125
+  offset_cycles: 320
   # w/o ignoring the plaintext loading and delay
-  #num_samples: 8900
-  #offset: 0
+  #num_cycles: 445
+  #offset_cycles: 0
   # 32-bit LFSR seed - Currently not used by the target for SHA3 captures.
   lfsr_seed: 0xdeadbeef
   batch_prng_seed: 0

--- a/cw/capture_sha3_masks_off_cw310.yaml
+++ b/cw/capture_sha3_masks_off_cw310.yaml
@@ -12,15 +12,15 @@ capture:
   # into the SHA3 core and the PRNG isn't advanced during SHA3 processing.
   # Works for SHA3 only. Doesn't work when processing key material.
   masks_off: true
-  # Samples per trace - We oversample by 20x and SHA3 with DOM is doing 120
+  # Number of target clock cycles per trace - SHA3 with DOM is doing 120
   # cycles (24 for loading and padding, 96 for processing) with 320 delay
   # cycles between loading the plaintext and adding the padding. The plaintext
   # loading and the delay cycles can be ignored.
-  num_samples: 2500
-  offset: 6400
+  num_cycles: 125
+  offset_cycles: 320
   # w/o ignoring the plaintext loading and delay
-  #num_samples: 8900
-  #offset: 0
+  #num_cycles: 445
+  #offset_cycles: 0
   # 32-bit LFSR seed - Currently not used by the target for SHA3 captures.
   lfsr_seed: 0xdeadbeef
   batch_prng_seed: 0

--- a/cw/cw_segmented.py
+++ b/cw/cw_segmented.py
@@ -50,8 +50,8 @@ class CwSegmented:
             this many trigger events. Read-only.
     """
 
-    def __init__(self, num_samples=1200, offset=0, scope_gain=23, scope=None,
-                 pll_frequency=100000000):
+    def __init__(self, num_samples=1200, offset_samples=0, scope_gain=23, scope=None,
+                 clkgen_freq=100e6, adc_mul=2):
         """Inits a CwSegmented.
 
         Args:
@@ -63,7 +63,7 @@ class CwSegmented:
         else:
             self._scope = cw.scope()
 
-        self._configure_scope(scope_gain, offset, pll_frequency)
+        self._configure_scope(scope_gain, offset_samples, clkgen_freq, adc_mul)
 
         self.num_segments = 1
         self.num_samples = num_samples
@@ -117,17 +117,16 @@ class CwSegmented:
             print(f"Warning: Adjusting number of segments to {self.num_segments_max}.")
             self.num_segments = self.num_segments_max
 
-    def _configure_scope(self, scope_gain, offset, pll_frequency):
+    def _configure_scope(self, scope_gain, offset_samples, clkgen_freq, adc_mul):
         self._scope.gain.db = scope_gain
-        if offset >= 0:
-            self._scope.adc.offset = offset
+        if offset_samples >= 0:
+            self._scope.adc.offset = offset_samples
         else:
             self._scope.adc.offset = 0
-            self._scope.adc.presamples = -offset
+            self._scope.adc.presamples = -offset_samples
         self._scope.adc.basic_mode = "rising_edge"
-        # We sample using the target clock * 2 (200 MHz).
-        self._scope.clock.adc_mul = 2
-        self._scope.clock.clkgen_freq = pll_frequency
+        self._scope.clock.adc_mul = adc_mul
+        self._scope.clock.clkgen_freq = clkgen_freq
         self._scope.clock.clkgen_src = 'extclk'
 
         self._scope.trigger.triggers = "tio4"

--- a/cw/husky_dispatcher.py
+++ b/cw/husky_dispatcher.py
@@ -17,11 +17,12 @@ class HuskyDispatcher:
         if self.num_segments == 1:
             self.scope = opentitan_device.scope
         else:  # Batch mode
-            self.scope = CwSegmented(num_samples=opentitan_device.scope.adc.samples,
-                                     offset=opentitan_device.scope.adc.offset,
+            self.scope = CwSegmented(num_samples=opentitan_device.num_samples,
+                                     offset_samples=opentitan_device.offset_samples,
                                      scope_gain=opentitan_device.scope.gain.db,
                                      scope=opentitan_device.scope,
-                                     pll_frequency=opentitan_device.scope.clock.clkgen_freq)
+                                     clkgen_freq=opentitan_device.scope.clock.clkgen_freq,
+                                     adc_mul=opentitan_device.adc_mul)
             self.scope.num_segments = num_segments
 
     def arm(self):

--- a/cw/simple_capture_aes_sca.py
+++ b/cw/simple_capture_aes_sca.py
@@ -62,10 +62,11 @@ if __name__ == '__main__':
                                    cfg["cwfpgahusky"]["force_program_bitstream"],
                                    cfg["cwfpgahusky"]["fw_bin"],
                                    cfg["cwfpgahusky"]["pll_frequency"],
+                                   cfg["cwfpgahusky"]["target_clk_mult"],
                                    cfg["cwfpgahusky"]["baudrate"],
                                    cfg["cwfpgahusky"]["scope_gain"],
-                                   cfg["cwfpgahusky"]["num_samples"],
-                                   cfg["cwfpgahusky"]["offset"],
+                                   cfg["cwfpgahusky"]["num_cycles"],
+                                   cfg["cwfpgahusky"]["offset_cycles"],
                                    cfg["cwfpgahusky"]["output_len_bytes"])
 
     if HUSKY:

--- a/cw/simple_capture_aes_sca.yaml
+++ b/cw/simple_capture_aes_sca.yaml
@@ -5,9 +5,10 @@ cwfpgahusky:
   baudrate: 115200
   output_len_bytes: 16
   pll_frequency: 100000000
+  target_clk_mult: 0.1
   num_segments: 20
-  num_samples: 1200
-  offset: -40
+  num_cycles: 60
+  offset_cycles: -2
   scope_gain: 38
 waverunner:
   waverunner_ip: 100.107.71.10

--- a/cw/util/device.py
+++ b/cw/util/device.py
@@ -127,26 +127,16 @@ class OpenTitan(object):
         scope = cw.scope()
         scope.gain.db = scope_gain
         scope.adc.basic_mode = "rising_edge"
-        if hasattr(scope, '_is_husky') and scope._is_husky:
-            # We sample using the target clock * 2 (200 MHz).
-            scope.clock.clkgen_src = 'extclk'
-            # To fully capture the long OTBN applications,
-            # we may need to use pll_frequencies other than 100 MHz.
-            scope.clock.clkgen_freq = pll_frequency
-            scope.clock.adc_mul = 2
-            scope.clock.extclk_monitor_enabled = False
-            scope.adc.samples = num_samples
 
-            husky = True
-            print(f"Husky? = {husky}")
-        else:
-            # We sample using the target clock (100 MHz).
-            scope.clock.adc_mul = 1
-            scope.clock.clkgen_freq = 100000000
-            scope.adc.samples = num_samples // 2
-            offset = offset // 2
-            scope.clock.adc_src = 'extclk_dir'
-            husky = False
+        # We sample using the target clock * 2 (200 MHz).
+        scope.clock.clkgen_src = 'extclk'
+        # To fully capture the long OTBN applications,
+        # we may need to use pll_frequencies other than 100 MHz.
+        scope.clock.clkgen_freq = pll_frequency
+        scope.clock.adc_mul = 2
+        scope.clock.extclk_monitor_enabled = False
+        scope.adc.samples = num_samples
+
         if offset >= 0:
             scope.adc.offset = offset
         else:
@@ -158,13 +148,7 @@ class OpenTitan(object):
         scope.io.hs2 = "disabled"
 
         # Make sure that clkgen_locked is true.
-        if husky:
-            scope.clock.clkgen_src = 'extclk'
-
-        # TODO: Need to update error handling.
-        if not husky:
-            scope.clock.reset_adc()
-            time.sleep(0.5)
+        scope.clock.clkgen_src = 'extclk'
 
         # Wait for ADC to lock.
         ping_cnt = 0


### PR DESCRIPTION
Specify offset in target clock cycles, rather than number of samples.
Partially addresses #177 
For the time being, I've added offset adjustment in the scope code (`cw_segmented.py` and `device.py`), because that's where we can read the sampling rate.
Perhaps there is an elegant way to do this computation without touching the scope code, but I don't see it at the moment.
