### PR TITLE
Update AES CW305 binary

### DIFF
--- a/cw/objs/aes_serial_fpga_cw305.bin
+++ b/cw/objs/aes_serial_fpga_cw305.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5c0f8b459ef9a65fc6824254dbb8d6ccc16194f22c9d2a37004c38ee8f68f18
-size 29632
+oid sha256:f7fa0b76a5b71ee3b5a17a87186108d4396f97e2cbf6382a1b9e5a3185d21d2d
+size 34216


### PR DESCRIPTION
OT PR #20068 changes aes_serial.c to disable internal PRNG when 0 is writtern into lfsr.
This commit updates the binary for CW305

The binary was generated from:
https://github.com/vrozic/opentitan/tree/binary-aes-cw305

This branch contains the state of the OT repository before frequency change plus one commit with aes_serial.c changes