### PR TITLE
[scope] Autoconvert cycles into samples

### DIFF
--- a/capture/configs/aes_sca_cw310.yaml
+++ b/capture/configs/aes_sca_cw310.yaml
@@ -3,12 +3,13 @@ target:
   fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
   force_program_bitstream: True
   fw_bin: "../objs/aes_serial_fpga_cw310.bin"
-  pll_frequency: 100000000
+  # target_clk_mult is a hardcoded value in the bitstream. Do not change.
+  target_clk_mult: 0.24
+  target_freq: 24000000
   baudrate: 115200
   output_len_bytes: 16
 husky:
-  pll_frequency: 100000000
-  target_clk_mult: 0.24
+  sampling_rate: 200000000
   num_segments: 20
   num_cycles: 60
   offset_cycles: -2

--- a/capture/scopes/cycle_converter.py
+++ b/capture/scopes/cycle_converter.py
@@ -1,0 +1,38 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+
+def convert_num_cycles(cfg: dict, scope_type: str) -> int:
+    """ Convert number of cycles to number of samples.
+
+    As Husky is configured in number of samples, this function converts the
+    number of cycles to samples. The number of samples must be divisble by 3
+    for batch captures.
+
+    Args:
+        dict: The scope configuration.
+        scope_type: The used scope (Husky or WaveRunner).
+
+    Returns:
+        The number of samples.
+    """
+    sampling_target_ratio = cfg[scope_type].get("sampling_rate") / cfg["target"].get("target_freq")
+    num_samples = int(cfg[scope_type].get("num_cycles") * sampling_target_ratio)
+    if num_samples % 3:
+        num_samples = num_samples + 3 - (num_samples % 3)
+    return num_samples
+
+
+def convert_offset_cycles(cfg: dict, scope_type: str) -> int:
+    """ Convert offset in cycles to offset in samples.
+
+    Args:
+        dict: The scope configuration.
+        scope_type: The used scope (Husky or WaveRunner).
+
+    Returns:
+        The offset in samples.
+    """
+    sampling_target_ratio = cfg[scope_type].get("sampling_rate") / cfg["target"].get("target_freq")
+    return int(cfg[scope_type].get("offset_cycles") * sampling_target_ratio)

--- a/ci/cfg/ci_aes_sca_fvsr_cw310.yaml
+++ b/ci/cfg/ci_aes_sca_fvsr_cw310.yaml
@@ -3,12 +3,13 @@ target:
   fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
   force_program_bitstream: True
   fw_bin: "../objs/aes_serial_fpga_cw310.bin"
-  pll_frequency: 100000000
+  # target_clk_mult is a hardcoded value in the bitstream. Do not change.
+  target_clk_mult: 0.24
+  target_freq: 24000000
   baudrate: 115200
   output_len_bytes: 16
 husky:
-  pll_frequency: 100000000
-  target_clk_mult: 0.24
+  sampling_rate: 200000000
   num_segments: 20
   num_cycles: 60
   offset_cycles: -2

--- a/ci/cfg/ci_aes_sca_random_cw305.yaml
+++ b/ci/cfg/ci_aes_sca_random_cw305.yaml
@@ -3,12 +3,13 @@ target:
   fpga_bitstream: "../objs/lowrisc_systems_chip_englishbreakfast_cw305_0.1.bit"
   force_program_bitstream: True
   fw_bin: "../objs/aes_serial_fpga_cw305.bin"
-  pll_frequency: 100000000
+  # target_clk_mult is a hardcoded value in the bitstream. Do not change.
+  target_clk_mult: 0.1
+  target_freq: 10000000
   baudrate: 115200
   output_len_bytes: 16
 husky:
-  pll_frequency: 100000000
-  target_clk_mult: 0.1
+  sampling_rate: 200000000
   num_segments: 1
   num_cycles: 60
   offset_cycles: -2

--- a/ci/cfg/ci_aes_sca_random_cw310.yaml
+++ b/ci/cfg/ci_aes_sca_random_cw310.yaml
@@ -3,12 +3,13 @@ target:
   fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
   force_program_bitstream: True
   fw_bin: "../objs/aes_serial_fpga_cw310.bin"
-  pll_frequency: 100000000
+  # target_clk_mult is a hardcoded value in the bitstream. Do not change.
+  target_clk_mult: 0.24
+  target_freq: 24000000
   baudrate: 115200
   output_len_bytes: 16
 husky:
-  pll_frequency: 100000000
-  target_clk_mult: 0.24
+  sampling_rate: 200000000
   num_segments: 20
   num_cycles: 60
   offset_cycles: -2


### PR DESCRIPTION
Previously, the conversion from cycles into samples happened in the Husky scope driver. This PR moves this conversion into a library, allowing the user to either specify offset and windowlength in samples or cycles.
In addition, the sampling rate also can be changed in the config file.

In the future, we want to read the sampling rate from the scope.