### PR TITLE
[sca, kmac] Add new capture script for KMAC

### DIFF
--- a/capture/capture_kmac.py
+++ b/capture/capture_kmac.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Note: The word ciphertext refers to the tag in kmac
+#       To be compatible to the other capture scripts, the variable is
+#       called ciphertext
+
+import binascii
+import logging
+import random
+import signal
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from functools import partial
+from pathlib import Path
+
+import lib.helpers as helpers
+import numpy as np
+import yaml
+from Crypto.Hash import KMAC128
+from lib.ot_communication import OTKMAC
+from project_library.project import ProjectConfig, SCAProject
+from scopes.scope import Scope, ScopeConfig
+from tqdm import tqdm
+
+sys.path.append("../")
+from target.cw_fpga import CWFPGA  # noqa: E402
+from util import check_version  # noqa: E402
+from util import plot  # noqa: E402
+from util import data_generator as dg  # noqa: E402
+
+logger = logging.getLogger()
+
+
+def abort_handler_during_loop(this_project, sig, frame):
+    """ Abort capture and store traces.
+
+    Args:
+        this_project: Project instance.
+    """
+    if this_project is not None:
+        logger.info("\nHandling keyboard interrupt")
+        this_project.close(save=True)
+    sys.exit(0)
+
+
+@dataclass
+class CaptureConfig:
+    """ Configuration class for the current capture.
+    """
+    capture_mode: str
+    batch_mode: bool
+    num_traces: int
+    num_segments: int
+    output_len: int
+    text_fixed: bytearray
+    key_fixed: bytearray
+    key_len_bytes: int
+    text_len_bytes: int
+
+
+def setup(cfg: dict, project: Path):
+    """ Setup target, scope, and project.
+
+    Args:
+        cfg: The configuration for the current experiment.
+        project: The path for the project file.
+
+    Returns:
+        The target, scope, and project.
+    """
+    # Init target.
+    logger.info(f"Initializing target {cfg['target']['target_type']} ...")
+    target = CWFPGA(
+        bitstream = cfg["target"]["fpga_bitstream"],
+        force_programming = cfg["target"]["force_program_bitstream"],
+        firmware = cfg["target"]["fw_bin"],
+        pll_frequency = cfg["target"]["pll_frequency"],
+        baudrate = cfg["target"]["baudrate"],
+        output_len = cfg["target"]["output_len_bytes"],
+    )
+
+    # Init scope.
+    scope_type = cfg["capture"]["scope_select"]
+    logger.info(f"Initializing scope {scope_type} ...")
+    scope_cfg = ScopeConfig(
+        scope_type = scope_type,
+        acqu_channel = cfg[scope_type].get("channel"),
+        ip = cfg[scope_type].get("waverunner_ip"),
+        num_samples = cfg[scope_type].get("num_samples"),
+        offset_samples = cfg[scope_type].get("offset_samples"),
+        num_segments = cfg[scope_type]["num_segments"],
+        sparsing = cfg[scope_type].get("sparsing"),
+        scope_gain = cfg[scope_type].get("scope_gain"),
+        pll_frequency = cfg["target"]["pll_frequency"],
+    )
+    scope = Scope(scope_cfg)
+
+    # Init project.
+    project_cfg = ProjectConfig(type = cfg["capture"]["trace_db"],
+                                path = project,
+                                wave_dtype = np.uint16,
+                                overwrite = True,
+                                trace_threshold = cfg["capture"].get("trace_threshold")
+                                )
+    project = SCAProject(project_cfg)
+    project.create_project()
+
+    return target, scope, project
+
+
+def configure_cipher(cfg, target, capture_cfg) -> OTKMAC:
+    """ Configure the KMAC cipher.
+
+    Establish communication with the KMAC cipher and configure the seed.
+
+    Args:
+        cfg: The project config.
+        target: The OT target.
+        capture_cfg: The capture config.
+
+    Returns:
+        The communication interface to the KMAC cipher.
+    """
+    # Create communication interface to OT KMAC.
+    ot_kmac = OTKMAC(target.target)
+
+    # If batch mode, configure PRNGs.
+    if capture_cfg.batch_mode:
+        # Seed host's PRNG.
+        random.seed(cfg["test"]["batch_prng_seed"])
+
+        # Seed the target's PRNGs for initial key masking, and additionally
+        # turn off masking when '0'.
+        ot_kmac.write_lfsr_seed(cfg["test"]["lfsr_seed"].to_bytes(4, "little"))
+        ot_kmac.write_batch_prng_seed(cfg["test"]["batch_prng_seed"].to_bytes(4, "little"))
+
+    return ot_kmac
+
+
+def generate_ref_crypto(sample_fixed, mode, batch, key, key_fixed, plaintext,
+                        plaintext_fixed, key_length):
+    """ Generate cipher material for the encryption.
+
+    This function derives the next key as well as the plaintext for the next
+    encryption.
+
+    Args:
+        sample_fixed: Use fixed key or new key.
+        mode: The mode of the capture.
+        batch: Batch or non-batch mode.
+        key: The current key.
+        key_fixed: The fixed key for FVSR.
+        plaintext: The current plaintext.
+        plaintext_fixed: The fixed plaintext for FVSR.
+        key_length: Th length of the key.
+
+    Returns:
+        plaintext: The next plaintext.
+        key: The next key.
+        ciphertext: The next ciphertext.
+        sample_fixed: Is the next sample fixed or not?
+    """
+    if mode == "kmac_fvsr_key" and not batch:
+        # returns a pt, ct, key tripple
+        # does only need the sample_fixed argument
+        if sample_fixed:
+            # Expected ciphertext.
+            plaintext, ciphertext, key = dg.get_kmac_fixed()
+        else:
+            plaintext, ciphertext, key = dg.get_kmac_random()
+        # The next sample is either fixed or random.
+        sample_fixed = plaintext[0] & 0x1
+    else:
+        if mode == "kmac_random":
+            # returns pt, ct, key, needs key and pt as arguments
+            mac = KMAC128.new(key=bytes(key), mac_len=32)
+            mac.update(bytes(plaintext))
+            ciphertext = bytearray(mac.digest())
+        else:
+            # returns random pt, ct, key, needs no arguments
+            if sample_fixed:
+                # Use fixed_key as this key.
+                key = np.asarray(key_fixed)
+            else:
+                # Generate this key from the PRNG.
+                key = bytearray(key_length)
+                for i in range(0, key_length):
+                    key[i] = random.randint(0, 255)
+            # Always generate this plaintext from PRNG (including very first one).
+            plaintext = bytearray(16)
+            for i in range(0, 16):
+                plaintext[i] = random.randint(0, 255)
+            # Compute ciphertext for this key and plaintext.
+            mac = KMAC128.new(key=bytes(key), mac_len=32)
+            mac.update(bytes(plaintext))
+            ciphertext = bytearray(mac.digest())
+            # Determine if next iteration uses fixed_key.
+            sample_fixed = plaintext[0] & 0x1
+
+    return plaintext, key, ciphertext, sample_fixed
+
+
+def check_ciphertext(ot_kmac, expected_last_ciphertext, ciphertext_len):
+    """ Compares the received with the generated ciphertext.
+
+    Ciphertext is read from the device and compared against the pre-computed
+    generated ciphertext. In batch mode, only the last ciphertext is compared.
+    Asserts on mismatch.
+
+    Args:
+        ot_kmac: The OpenTitan KMAC communication interface.
+        expected_last_ciphertext: The pre-computed ciphertext.
+        ciphertext_len: The length of the ciphertext in bytes.
+    """
+    actual_last_ciphertext = ot_kmac.read_ciphertext(ciphertext_len)
+    assert actual_last_ciphertext == expected_last_ciphertext[0:ciphertext_len], (
+        f"Incorrect encryption result!\n"
+        f"actual:   {actual_last_ciphertext}\n"
+        f"expected: {expected_last_ciphertext}"
+    )
+
+
+def capture(scope: Scope, ot_kmac: OTKMAC, capture_cfg: CaptureConfig,
+            project: SCAProject, cwtarget: CWFPGA):
+    """ Capture power consumption during KMAC Tag computation.
+
+    Supports four different capture types:
+    * kmac_random: Fixed key, random plaintext.
+    * kmac_random_batch: Fixed key, random plaintext in batch mode.
+    * kmac_fvsr: Fixed vs. random key.
+    * kmac_fvsr_batch: Fixed vs. random key batch.
+
+    Args:
+        scope: The scope class representing a scope (Husky or WaveRunner).
+        ot_kmac: The OpenTitan KMAC communication interface.
+        capture_cfg: The configuration of the capture.
+        project: The SCA project.
+        cwtarget: The CW FPGA target.
+    """
+    # Initial plaintext.
+    text_fixed = bytearray(capture_cfg.text_fixed)
+    text = text_fixed
+    # Load fixed key.
+    key_fixed = bytearray(capture_cfg.key_fixed)
+    key = key_fixed
+
+    # FVSR setup.
+    # in the kmac_serial.c: `static bool run_fixed = false;`
+    # we should adjust this throughout all scripts.
+    sample_fixed = 0
+
+    logger.info(f"Initializing OT KMAC with key {binascii.b2a_hex(bytes(key))} ...")
+    if capture_cfg.capture_mode == "kmac_fvsr_key":
+        ot_kmac.fvsr_key_set(key)
+    else:
+        ot_kmac.write_key(key)
+
+    # Optimization for CW trace library.
+    num_segments_storage = 1
+
+    # Register ctrl-c handler to store traces on abort.
+    signal.signal(signal.SIGINT, partial(abort_handler_during_loop, project))
+    # Main capture with progress bar.
+    remaining_num_traces = capture_cfg.num_traces
+    with tqdm(total=remaining_num_traces, desc="Capturing", ncols=80, unit=" traces") as pbar:
+        while remaining_num_traces > 0:
+            # Arm the scope.
+            scope.arm()
+            # Trigger encryption.
+            if capture_cfg.batch_mode:
+                # Batch mode. Is always kmac_fvsr_key
+                ot_kmac.absorb_batch(
+                    capture_cfg.num_segments.to_bytes(4, "little"))
+            else:
+                # Non batch mode. either random or fvsr
+                if capture_cfg.capture_mode == "kmac_fvsr_key":
+                    text, key, ciphertext, sample_fixed = generate_ref_crypto(
+                        sample_fixed = sample_fixed,
+                        mode = capture_cfg.capture_mode,
+                        batch = capture_cfg.batch_mode,
+                        key = key,
+                        key_fixed = key_fixed,
+                        plaintext = text,
+                        plaintext_fixed = text_fixed,
+                        key_length = capture_cfg.key_len_bytes
+                    )
+                    ot_kmac.write_key(key)
+                ot_kmac.absorb(text)
+            # Capture traces.
+            waves = scope.capture_and_transfer_waves(cwtarget.target)
+            assert waves.shape[0] == capture_cfg.num_segments
+
+            expected_ciphertext = None
+            # Generate reference crypto material and store trace.
+            for i in range(capture_cfg.num_segments):
+                if capture_cfg.batch_mode or capture_cfg.capture_mode == "kmac_random":
+                    text, key, ciphertext, sample_fixed = generate_ref_crypto(
+                        sample_fixed = sample_fixed,
+                        mode = capture_cfg.capture_mode,
+                        batch = capture_cfg.batch_mode,
+                        key = key,
+                        key_fixed = key_fixed,
+                        plaintext = text,
+                        plaintext_fixed = text_fixed,
+                        key_length = capture_cfg.key_len_bytes
+                    )
+                # Sanity check retrieved data (wave).
+                assert len(waves[i, :]) >= 1
+                # Store trace into database.
+                project.append_trace(wave = waves[i, :],
+                                     plaintext = text,
+                                     ciphertext = ciphertext,
+                                     key = key)
+
+                if capture_cfg.capture_mode == "kmac_random":
+                    plaintext = bytearray(16)
+                    for i in range(0, 16):
+                        plaintext[i] = random.randint(0, 255)
+
+                if capture_cfg.batch_mode:
+                    expected_ciphertext = (ciphertext if expected_ciphertext is None else
+                                           bytearray(a ^ b for (a, b) in zip(ciphertext,
+                                                                             expected_ciphertext)))
+                else:
+                    expected_ciphertext = ciphertext
+
+            # Compare received ciphertext with generated.
+            compare_len = capture_cfg.output_len
+            check_ciphertext(ot_kmac, expected_ciphertext, compare_len)
+
+            # Memory allocation optimization for CW trace library.
+            num_segments_storage = project.optimize_capture(num_segments_storage)
+
+            # Update the loop variable and the progress bar.
+            remaining_num_traces -= capture_cfg.num_segments
+            pbar.update(capture_cfg.num_segments)
+
+
+def print_plot(project: SCAProject, config: dict) -> None:
+    """ Print plot of traces.
+
+    Printing the plot helps to adjust the scope gain and check for clipping.
+
+    Args:
+        project: The project containing the traces.
+        config: The capture configuration.
+    """
+    if config["capture"]["show_plot"]:
+        plot.save_plot_to_file(project.get_waves(0, config["capture"]["plot_traces"]),
+                               set_indices = None,
+                               num_traces = config["capture"]["plot_traces"],
+                               outfile = config["capture"]["trace_image_filename"],
+                               add_mean_stddev=True)
+        print(f'Created plot with {config["capture"]["plot_traces"]} traces: '
+              f'{Path(config["capture"]["trace_image_filename"]).resolve()}')
+
+
+def main(argv=None):
+    # Configure the logger.
+    logger.setLevel(logging.INFO)
+    console = logging.StreamHandler()
+    logger.addHandler(console)
+
+    # Parse the provided arguments.
+    args = helpers.parse_arguments(argv)
+
+    # Check the ChipWhisperer version.
+    check_version.check_cw("5.7.0")
+
+    # Load configuration from file.
+    with open(args.cfg) as f:
+        cfg = yaml.load(f, Loader=yaml.FullLoader)
+
+    # Determine the capture mode and configure the current capture.
+    mode = "kmac_fvsr_key"
+    batch = False
+    if "kmac_random" in cfg["test"]["which_test"]:
+        mode = "kmac_random"
+    if "batch" in cfg["test"]["which_test"]:
+        batch = True
+    else:
+        # For non-batch mode, make sure that num_segments = 1.
+        cfg[cfg["capture"]["scope_select"]]["num_segments"] = 1
+        logger.info("num_segments needs to be 1 in non-batch mode. Setting num_segments=1.")
+
+    # Setup the target, scope and project.
+    target, scope, project = setup(cfg, args.project)
+
+    # Create capture config object.
+    capture_cfg = CaptureConfig(capture_mode = mode,
+                                batch_mode = batch,
+                                num_traces = cfg["capture"]["num_traces"],
+                                num_segments = cfg[cfg["capture"]["scope_select"]]["num_segments"],
+                                output_len = cfg["target"]["output_len_bytes"],
+                                text_fixed = cfg["test"]["text_fixed"],
+                                key_fixed = cfg["test"]["key_fixed"],
+                                key_len_bytes = cfg["test"]["key_len_bytes"],
+                                text_len_bytes = cfg["test"]["text_len_bytes"])
+    logger.info(f"Setting up capture {capture_cfg.capture_mode} batch={capture_cfg.batch_mode}...")
+
+    # Configure cipher.
+    ot_kmac = configure_cipher(cfg, target, capture_cfg)
+
+    # Capture traces.
+    capture(scope, ot_kmac, capture_cfg, project, target)
+
+    # Print plot.
+    print_plot(project, cfg)
+
+    # Save metadata.
+    metadata = {}
+    metadata["datetime"] = datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
+    metadata["cfg"] = cfg
+    metadata["num_samples"] = scope.scope_cfg.num_samples
+    metadata["offset_samples"] = scope.scope_cfg.offset_samples
+    metadata["scope_gain"] = scope.scope_cfg.scope_gain
+    metadata["cfg_file"] = str(args.cfg)
+    metadata["fpga_bitstream"] = cfg["target"]["fpga_bitstream"]
+    # TODO: Store binary into database instead of binary path.
+    # (Issue lowrisc/ot-sca#214)
+    metadata["fw_bin"] = cfg["target"]["fw_bin"]
+    # TODO: Allow user to enter notes via CLI.
+    # (Issue lowrisc/ot-sca#213)
+    metadata["notes"] = ""
+    project.write_metadata(metadata)
+
+    # Save and close project.
+    project.save()
+
+
+if __name__ == "__main__":
+    main()

--- a/capture/configs/capture_kmac_cw310.yaml
+++ b/capture/configs/capture_kmac_cw310.yaml
@@ -1,18 +1,15 @@
-device:
-  fpga_bitstream: objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
+target:
+  target_type: cw310
+  fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
-  fw_bin: objs/kmac_serial_fpga_cw310.bin
-  # The clock frequency of the target block is equal to
-  # pll_frequency * target_clk_mult. pll_frequency is controllable via
-  # ChipWhisperer API, whereas target_clk_mult is baked into the FPGA
-  # bitstream.
+  fw_bin: ../objs/kmac_serial_fpga_cw310.bin
+  pll_frequency: 100000000
+  baudrate: 115200
+  output_len_bytes: 32
+husky:
   pll_frequency: 100000000
   target_clk_mult: 0.24
-  baudrate: 115200
-capture:
-  key_len_bytes: 16
-  plain_text_len_bytes: 16
-  output_len_bytes: 32
+  num_segments: 20
   # Number of target clock cycles per trace - KMAC is doing 24 or 96 cycles
   # for the key absorb w/o or w/ DOM, respectively, as well as 23 cycles for
   # XORing the key into the state.
@@ -20,6 +17,7 @@ capture:
   #num_cycles: 80
   # w/ DOM
   num_cycles: 160
+  num_samples: 10 #fixme
   # Offset in target clock cycles - During the first activity block, KMAC
   # just absorbs the fixed prefix (23 cycles XORing + 24 or 96 cycles
   # absorbing w/o or w/ DOM, respectively). This first activity block can be
@@ -28,6 +26,24 @@ capture:
   #offset_cyles: 43
   # w/ DOM
   offset_cycles: 115
+  offset_samples: 1 #fixme
+  scope_gain: 26
+capture:
+  scope_select: husky
+  num_traces: 1000
+  show_plot: True
+  plot_traces: 100
+  trace_image_filename: projects/sample_traces_kmac.html
+  trace_db: ot_trace_library
+  trace_threshold: 10000
+test:
+  #which_test: kmac_random
+  #which_test: kmac_fvsr_key
+  which_test: kmac_fvsr_key_batch
+  key_len_bytes: 16
+  key_fixed: [0x81, 0x1E, 0x37, 0x31, 0xB0, 0x12, 0x0A, 0x78, 0x42, 0x78, 0x1E, 0x22, 0xB2, 0x5C, 0xDD, 0xF9]
+  text_len_bytes: 16
+  text_fixed: [0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA]
   # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
   # For unprotected implemetation, lfsr_seed should be set to 0. This will
   # effectively switch off the masking. For masked implementation, any seed
@@ -36,12 +52,5 @@ capture:
   #lfsr_seed: 0
   # w/ DOM
   lfsr_seed: 0xdeadbeef
+  # seed for PRNG to generate sequence of plaintexts and keys; Python random class on host, Mersenne twister implementation on OT SW
   batch_prng_seed: 0
-  scope_gain: 26
-  num_traces: 5000
-  project_name: projects/opentitan_simple_kmac
-  waverunner_ip: 192.168.1.228
-plot_capture:
-  show: true
-  num_traces: 100
-  trace_image_filename: projects/sample_traces_kmac.html

--- a/capture/configs/kmac_cw310.yaml
+++ b/capture/configs/kmac_cw310.yaml
@@ -3,12 +3,12 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: ../objs/kmac_serial_fpga_cw310.bin
-  pll_frequency: 100000000
+  target_clk_mult: 0.24
+  target_freq: 24000000
   baudrate: 115200
   output_len_bytes: 32
 husky:
-  pll_frequency: 100000000
-  target_clk_mult: 0.24
+  sampling_rate: 200000000
   num_segments: 20
   # Number of target clock cycles per trace - KMAC is doing 24 or 96 cycles
   # for the key absorb w/o or w/ DOM, respectively, as well as 23 cycles for
@@ -17,7 +17,6 @@ husky:
   #num_cycles: 80
   # w/ DOM
   num_cycles: 160
-  num_samples: 10 #fixme
   # Offset in target clock cycles - During the first activity block, KMAC
   # just absorbs the fixed prefix (23 cycles XORing + 24 or 96 cycles
   # absorbing w/o or w/ DOM, respectively). This first activity block can be
@@ -26,7 +25,6 @@ husky:
   #offset_cyles: 43
   # w/ DOM
   offset_cycles: 115
-  offset_samples: 1 #fixme
   scope_gain: 26
 capture:
   scope_select: husky

--- a/capture/lib/ot_communication.py
+++ b/capture/lib/ot_communication.py
@@ -93,3 +93,60 @@ class OTAES:
             The received ciphertext.
         """
         return self.target.simpleserial_read("r", len_bytes, ack=False)
+
+
+class OTKMAC:
+    def __init__(self, target) -> None:
+        self.target = target
+
+    def write_key(self, key):
+        """ Write the key to KMAC.
+        Args:
+            key: Bytearray containing the key.
+        """
+        self.target.simpleserial_write("k", key)
+
+    def fvsr_key_set(self, key):
+        """ Write the fixed key to KMAC.
+        Args:
+            key: Bytearray containing the key.
+        """
+        self.target.simpleserial_write("f", key)
+
+    def write_lfsr_seed(self, seed):
+        """ Seed the LFSR.
+        Args:
+            seed: The 4-byte seed.
+        """
+        self.target.simpleserial_write("l", seed)
+
+    def write_batch_prng_seed(self, seed):
+        """ Seed the PRNG.
+        Args:
+            seed: The 4-byte seed.
+        """
+        self.target.simpleserial_write("s", seed)
+
+    def absorb_batch(self, num_segments):
+        """ Start absorb for batch.
+        Args:
+            num_segments: Number of encryptions to perform.
+        """
+        self.target.simpleserial_write("b", num_segments)
+
+    def absorb(self, text):
+        """ Write plaintext to OpenTitan KMAC & start absorb.
+        Args:
+            text: The plaintext bytearray.
+        """
+        self.target.simpleserial_write("p", text)
+
+    def read_ciphertext(self, len_bytes):
+        """ Read ciphertext from OpenTitan KMAC.
+        Args:
+            len_bytes: Number of bytes to read.
+
+        Returns:
+            The received ciphertext.
+        """
+        return self.target.simpleserial_read("r", len_bytes, ack=False)

--- a/util/data_generator.py
+++ b/util/data_generator.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 from Crypto.Cipher import AES
+from Crypto.Hash import KMAC128
 
 
 class data_generator():
@@ -60,6 +61,27 @@ class data_generator():
         self.advance_random()
         return pt, ct, key
 
+    def get_kmac_fixed(self):
+        pt = np.asarray(self.text_fixed)
+        key = np.asarray(self.key_fixed)
+        mac_fixed = KMAC128.new(key=bytes(self.key_fixed), mac_len=32)
+        mac_fixed.update(bytes(self.text_fixed))
+        ct = np.asarray(bytearray(mac_fixed.digest()))
+        del (mac_fixed)
+        self.advance_fixed()
+        return pt, ct, key
+
+    def get_kmac_random(self):
+        pt = np.asarray(self.text_random)
+        key = np.asarray(self.key_random)
+        mac_random = KMAC128.new(key=bytes(self.key_random), mac_len=32)
+        mac_random.update(bytes(self.text_random))
+        ct = np.asarray(bytearray(mac_random.digest()))
+
+        del (mac_random)
+        self.advance_random()
+        return pt, ct, key
+
 
 # ----------------------------------------------------------------------
 # Create one instance, and export its methods as module-level functions.
@@ -69,3 +91,5 @@ _inst = data_generator()
 set_start = _inst.set_start
 get_fixed = _inst.get_fixed
 get_random = _inst.get_random
+get_kmac_fixed = _inst.get_kmac_fixed
+get_kmac_random = _inst.get_kmac_random


### PR DESCRIPTION
This PR addresses https://github.com/lowRISC/ot-sca/issues/217

As this was a major rework, it would be good if s.o. could test if the TVLA still works.

There are three open points:
 1.  FIXMEs in the config file: I'm not sure how to translate the cycles vs. samples
 2. In the non-bach fvsr-mode, the internal PRNG is used not AES. This is the same behavior as in the old-script. However we should adjust this eventually.
 3. The keyword "ciphertext" is used throughout the script. We should change this to mac or tag eventually.
