### PR TITLE
Pin Python requirements to version

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -3,28 +3,28 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Keep sorted.
-bokeh<3.0.0
-cffi
-codetiming
-libusb1
-matplotlib
-more-itertools
-networkx
-pycryptodome >= 3.12.0
+bokeh==2.4.3
+cffi==1.16.0
+codetiming==1.4.0
+libusb1==3.1.0
+matplotlib==3.8.1
+more-itertools==10.1.0
+networkx==3.2.1
+pycryptodome==3.19.0
 # TODO: Use pyvisa instead after switching to a dedicated PRNG
-python-vxi11
-pyyaml
-ray
-scared
-scipy
-sqlalchemy
-sqlalchemy_utils
-tqdm
-trsfile
-typer
-wheel
+python-vxi11==0.9
+pyyaml==6.0.1
+ray==2.8.0
+scared==1.1.0
+scipy==1.11.3
+sqlalchemy==2.0.23
+sqlalchemy_utils==0.41.1
+tqdm==4.66.1
+trsfile==2.2.0
+typer==0.9.0
+wheel==0.41.3
 # can be removed after switching to ray
-joblib
+joblib==1.3.2
 
 # Development version of ChipWhisperer toolchain with latest features and
 # bug fixes - Needs to be installed in editable mode. We fix the version
@@ -35,4 +35,4 @@ joblib
 -r python-requirements-lint.txt
 
 # Test-only requirements
-pytest
+pytest==7.4.3


### PR DESCRIPTION
As discovered by @johannheyszl, some sqlalchemy versions cause issues when fetching data from the DB. This PR pins all Python requirements to a specifc version. The versions are identical to what currently is used in the podman container.