### PR TITLE
Create project dir automatically

### DIFF
--- a/capture/lib/helpers.py
+++ b/capture/lib/helpers.py
@@ -32,7 +32,8 @@ def ap_check_dir_exists(path: str) -> Path:
     """
     path = Path(path)
     if not path.parent.exists():
-        raise argparse.ArgumentTypeError(f"Path {path.parent} does not exist")
+        print(f"Path {path.parent} does not exist, creating directory...")
+        path.parent.mkdir(parents=True, exist_ok=True)
     return path
 
 


### PR DESCRIPTION
Previously, an error was thrown when the project dir (-p argument) was not provided. Now, instead a warning is printed and the dir is created.