### PR TITLE
Fetch path of plot from cmd line args

### DIFF
--- a/capture/capture_aes.py
+++ b/capture/capture_aes.py
@@ -315,7 +315,7 @@ def capture(scope: Scope, ot_aes: OTAES, capture_cfg: CaptureConfig,
             pbar.update(capture_cfg.num_segments)
 
 
-def print_plot(project: SCAProject, config: dict) -> None:
+def print_plot(project: SCAProject, config: dict, file: Path) -> None:
     """ Print plot of traces.
 
     Printing the plot helps to adjust the scope gain and check for clipping.
@@ -323,15 +323,16 @@ def print_plot(project: SCAProject, config: dict) -> None:
     Args:
         project: The project containing the traces.
         config: The capture configuration.
+        file: The output file path.
     """
     if config["capture"]["show_plot"]:
         plot.save_plot_to_file(project.get_waves(0, config["capture"]["plot_traces"]),
                                set_indices = None,
                                num_traces = config["capture"]["plot_traces"],
-                               outfile = config["capture"]["trace_image_filename"],
+                               outfile = file,
                                add_mean_stddev=True)
         print(f'Created plot with {config["capture"]["plot_traces"]} traces: '
-              f'{Path(config["capture"]["trace_image_filename"]).resolve()}')
+              f'{Path(str(file) + ".html").resolve()}')
 
 
 def main(argv=None):
@@ -384,7 +385,7 @@ def main(argv=None):
     capture(scope, ot_aes, capture_cfg, project, target)
 
     # Print plot.
-    print_plot(project, cfg)
+    print_plot(project, cfg, args.project)
 
     # Save metadata.
     metadata = {}

--- a/capture/configs/aes_sca_cw310.yaml
+++ b/capture/configs/aes_sca_cw310.yaml
@@ -25,7 +25,6 @@ capture:
   num_traces: 1000
   show_plot: True
   plot_traces: 100
-  trace_image_filename: "projects/simple_capture_aes_sca_sample_traces.html"
   trace_db: ot_trace_library
   trace_threshold: 10000
   # trace_db: cw

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -83,6 +83,6 @@ jobs:
       ../capture/capture_aes.py -c cfg/ci_aes_sca_random_cw305.yaml -p projects/aes_sca_random_cw305
       popd
     displayName: "Capture AES Random Key traces"
-  - publish: ./ci/projects/aes_sca_fvsr_cw305.html
+  - publish: ./ci/projects/aes_sca_random_cw305.html
     artifact: traces_aes_random_cw305
     displayName: "Upload AES Random Key traces"

--- a/ci/cfg/ci_aes_sca_fvsr_cw310.yaml
+++ b/ci/cfg/ci_aes_sca_fvsr_cw310.yaml
@@ -25,7 +25,6 @@ capture:
   num_traces: 1000
   show_plot: True
   plot_traces: 100
-  trace_image_filename: "projects/aes_sca_fvsr_cw310.html"
   trace_db: ot_trace_library
   # trace_db: cw
   trace_threshold: 10000

--- a/ci/cfg/ci_aes_sca_random_cw305.yaml
+++ b/ci/cfg/ci_aes_sca_random_cw305.yaml
@@ -25,7 +25,6 @@ capture:
   num_traces: 500
   show_plot: True
   plot_traces: 100
-  trace_image_filename: "projects/aes_sca_fvsr_cw305.html"
   trace_db: ot_trace_library
   # trace_db: cw
   trace_threshold: 10000

--- a/ci/cfg/ci_aes_sca_random_cw310.yaml
+++ b/ci/cfg/ci_aes_sca_random_cw310.yaml
@@ -25,7 +25,6 @@ capture:
   num_traces: 1000
   show_plot: True
   plot_traces: 100
-  trace_image_filename: "projects/aes_sca_random_cw310.html"
   trace_db: ot_trace_library
   # trace_db: cw
   trace_threshold: 10000

--- a/util/plot.py
+++ b/util/plot.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools
+from pathlib import Path
 
 import numpy as np
 from bokeh.io import output_file
@@ -53,5 +54,5 @@ def save_plot_to_file(traces, set_indices, num_traces, outfile, add_mean_stddev=
                   line_width=2, legend_label='std')
         plot.line(xrange, mean, line_color='black', line_width=2, legend_label='mean')
 
-    output_file(outfile)
+    output_file(Path(str(outfile) + ".html"))
     show(plot)


### PR DESCRIPTION
In this PR, the path for the plot is taken from the -p command line argument instead from the config file. This streamlines the usage of the script.