### PR TITLE
[capture] Enable uJSON for KMAC

### DIFF
--- a/capture/capture_aes.py
+++ b/capture/capture_aes.py
@@ -30,6 +30,18 @@ from util import check_version  # noqa: E402
 from util import plot  # noqa: E402
 from util import data_generator as dg  # noqa: E402
 
+"""AES SCA capture script.
+
+Captures power traces during AES operations.
+
+The data format of the crypto material (ciphertext, plaintext, and key) inside
+the script is stored in plain integer arrays.
+
+Typical usage:
+>>> ./capture_aes.py -c configs/aes_sca_cw310.yaml -p projects/aes_sca_capture
+"""
+
+
 logger = logging.getLogger()
 
 
@@ -194,7 +206,8 @@ def generate_ref_crypto(sample_fixed, mode, key, plaintext):
     else:
         if mode == "aes_random":
             cipher = AES.new(bytes(key), AES.MODE_ECB)
-            ciphertext = bytearray(cipher.encrypt(bytes(plaintext)))
+            ciphertext_bytes = cipher.encrypt(bytes(plaintext))
+            ciphertext = [x for x in ciphertext_bytes]
 
     return plaintext, key, ciphertext, sample_fixed
 
@@ -353,8 +366,8 @@ def print_plot(project: SCAProject, config: dict, file: Path) -> None:
                                num_traces = config["capture"]["plot_traces"],
                                outfile = file,
                                add_mean_stddev=True)
-        print(f'Created plot with {config["capture"]["plot_traces"]} traces: '
-              f'{Path(str(file) + ".html").resolve()}')
+        logger.info(f'Created plot with {config["capture"]["plot_traces"]} traces: '
+                    f'{Path(str(file) + ".html").resolve()}')
 
 
 def main(argv=None):

--- a/capture/configs/kmac_cw310.yaml
+++ b/capture/configs/kmac_cw310.yaml
@@ -3,10 +3,15 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: ../objs/kmac_serial_fpga_cw310.bin
+  # fw_bin: "../objs/kmac_ujson_fpga_cw310.bin"
+  # target_clk_mult is a hardcoded value in the bitstream. Do not change.
   target_clk_mult: 0.24
   target_freq: 24000000
   baudrate: 115200
   output_len_bytes: 32
+  protocol: "simpleserial"
+  # protocol: "ujson"
+  # port: "/dev/ttyACM1"
 husky:
   sampling_rate: 200000000
   num_segments: 20
@@ -35,8 +40,8 @@ capture:
   trace_db: ot_trace_library
   trace_threshold: 10000
 test:
-  #which_test: kmac_random
-  #which_test: kmac_fvsr_key
+  # which_test: kmac_random
+  # which_test: kmac_fvsr_key
   which_test: kmac_fvsr_key_batch
   key_len_bytes: 16
   key_fixed: [0x81, 0x1E, 0x37, 0x31, 0xB0, 0x12, 0x0A, 0x78, 0x42, 0x78, 0x1E, 0x22, 0xB2, 0x5C, 0xDD, 0xF9]

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -4,8 +4,8 @@ pr:
     - "*"
 
 jobs:
-- job: sca_capture_cw310
-  displayName: "Capture SCA traces (CW310)"
+- job: aes_sca_capture_cw310
+  displayName: "Capture AES SCA traces (CW310)"
   timeoutInMinutes: 30
   pool:
     name: FPGA SCA
@@ -59,7 +59,7 @@ jobs:
       popd
     displayName: "Compare AES Random Key traces against golden trace"
 - job: sca_capture_cw305
-  displayName: "Capture SCA traces (CW305)"
+  displayName: "Capture AES SCA traces (CW305)"
   timeoutInMinutes: 30
   pool:
     name: FPGA SCA
@@ -86,3 +86,62 @@ jobs:
   - publish: ./ci/projects/aes_sca_random_cw305.html
     artifact: traces_aes_random_cw305
     displayName: "Upload AES Random Key traces"
+- job: kmac_sca_capture_cw310
+  displayName: "Capture KMAC SCA traces (CW310)"
+  timeoutInMinutes: 30
+  pool:
+    name: FPGA SCA
+    demands: BOARD -equals cw310
+  steps:
+  - checkout: self
+  - bash: |
+      python3 -m pip install --user -r python-requirements.txt
+    displayName: "Install python dependencies"
+  - bash: |
+      apt update
+      apt install git-lfs
+    displayName: "Install system dependencies"
+  - bash: |
+      git-lfs pull
+    displayName: "Pull LFS binaries"
+  - bash: |
+      set -e
+      pushd ci
+      mkdir -p projects
+      ../capture/capture_kmac.py -c cfg/ci_kmac_sca_fvsr_cw310_simpleserial.yaml -p projects/kmac_sca_fvsr_cw310_simpleserial
+      popd
+    displayName: "Capture KMAC FVSR traces (simpleserial)"
+  - publish: ./ci/projects/kmac_sca_fvsr_cw310_simpleserial.html
+    artifact: traces_kmac_fvsr_cw310_simpleserial
+    displayName: "Upload KMAC FVSR traces (simpleserial)"
+  - bash: |
+      set -e
+      pushd ci
+      mkdir -p projects
+      ../capture/capture_kmac.py -c cfg/ci_kmac_sca_fvsr_cw310_ujson.yaml -p projects/kmac_sca_fvsr_cw310_ujson
+      popd
+    displayName: "Capture KMAC FVSR traces (uJSON)"
+  - publish: ./ci/projects/kmac_sca_fvsr_cw310_ujson.html
+    artifact: traces_kmac_fvsr_cw310_ujson
+    displayName: "Upload KMAC FVSR traces (uJSON)"
+  - bash: |
+      set -e
+      pushd ci
+      mkdir -p projects
+      ../capture/capture_kmac.py -c cfg/ci_kmac_sca_random_cw310_simpleserial.yaml -p projects/kmac_sca_random_cw310_simpleserial
+      popd
+    displayName: "Capture KMAC Random traces (simpleserial)"
+  - publish: ./ci/projects/kmac_sca_random_cw310_simpleserial.html
+    artifact: traces_kmac_random_cw310_simpleserial
+    displayName: "Upload KMAC Random traces (simpleserial)"
+  - bash: |
+      set -e
+      pushd ci
+      mkdir -p projects
+      ../capture/capture_kmac.py -c cfg/ci_kmac_sca_random_cw310_ujson.yaml -p projects/kmac_sca_random_cw310_ujson
+      popd
+    displayName: "Capture KMAC Random traces (uJSON)"
+  - publish: ./ci/projects/kmac_sca_random_cw310_ujson.html
+    artifact: traces_kmac_random_cw310_ujson
+    displayName: "Upload KMAC Random traces (uJSON)"
+

--- a/ci/cfg/ci_kmac_sca_fvsr_cw310_simpleserial.yaml
+++ b/ci/cfg/ci_kmac_sca_fvsr_cw310_simpleserial.yaml
@@ -1,0 +1,59 @@
+target:
+  target_type: cw310
+  fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
+  force_program_bitstream: False
+  fw_bin: ../objs/kmac_serial_fpga_cw310.bin
+  # fw_bin: "../objs/kmac_ujson_fpga_cw310.bin"
+  # target_clk_mult is a hardcoded value in the bitstream. Do not change.
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  output_len_bytes: 32
+  protocol: "simpleserial"
+  # protocol: "ujson"
+  # port: "/dev/ttyACM_CW310_1"
+husky:
+  sampling_rate: 200000000
+  num_segments: 20
+  # Number of target clock cycles per trace - KMAC is doing 24 or 96 cycles
+  # for the key absorb w/o or w/ DOM, respectively, as well as 23 cycles for
+  # XORing the key into the state.
+  # w/o DOM
+  #num_cycles: 80
+  # w/ DOM
+  num_cycles: 160
+  # Offset in target clock cycles - During the first activity block, KMAC
+  # just absorbs the fixed prefix (23 cycles XORing + 24 or 96 cycles
+  # absorbing w/o or w/ DOM, respectively). This first activity block can be
+  # skipped
+  # w/o DOM
+  #offset_cyles: 43
+  # w/ DOM
+  offset_cycles: 115
+  scope_gain: 26
+capture:
+  scope_select: husky
+  num_traces: 1000
+  show_plot: True
+  plot_traces: 100
+  trace_image_filename: projects/sample_traces_kmac.html
+  trace_db: ot_trace_library
+  trace_threshold: 10000
+test:
+  # which_test: kmac_random
+  # which_test: kmac_fvsr_key
+  which_test: kmac_fvsr_key_batch
+  key_len_bytes: 16
+  key_fixed: [0x81, 0x1E, 0x37, 0x31, 0xB0, 0x12, 0x0A, 0x78, 0x42, 0x78, 0x1E, 0x22, 0xB2, 0x5C, 0xDD, 0xF9]
+  text_len_bytes: 16
+  text_fixed: [0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA]
+  # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
+  # For unprotected implemetation, lfsr_seed should be set to 0. This will
+  # effectively switch off the masking. For masked implementation, any seed
+  # other than 0 should be used.
+  # w/o DOM
+  #lfsr_seed: 0
+  # w/ DOM
+  lfsr_seed: 0xdeadbeef
+  # seed for PRNG to generate sequence of plaintexts and keys; Python random class on host, Mersenne twister implementation on OT SW
+  batch_prng_seed: 0

--- a/ci/cfg/ci_kmac_sca_fvsr_cw310_ujson.yaml
+++ b/ci/cfg/ci_kmac_sca_fvsr_cw310_ujson.yaml
@@ -1,0 +1,59 @@
+target:
+  target_type: cw310
+  fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
+  force_program_bitstream: False
+  # fw_bin: ../objs/kmac_serial_fpga_cw310.bin
+  fw_bin: "../objs/kmac_ujson_fpga_cw310.bin"
+  # target_clk_mult is a hardcoded value in the bitstream. Do not change.
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  output_len_bytes: 32
+  # protocol: "simpleserial"
+  protocol: "ujson"
+  port: "/dev/ttyACM_CW310_1"
+husky:
+  sampling_rate: 200000000
+  num_segments: 20
+  # Number of target clock cycles per trace - KMAC is doing 24 or 96 cycles
+  # for the key absorb w/o or w/ DOM, respectively, as well as 23 cycles for
+  # XORing the key into the state.
+  # w/o DOM
+  #num_cycles: 80
+  # w/ DOM
+  num_cycles: 160
+  # Offset in target clock cycles - During the first activity block, KMAC
+  # just absorbs the fixed prefix (23 cycles XORing + 24 or 96 cycles
+  # absorbing w/o or w/ DOM, respectively). This first activity block can be
+  # skipped
+  # w/o DOM
+  #offset_cyles: 43
+  # w/ DOM
+  offset_cycles: 115
+  scope_gain: 26
+capture:
+  scope_select: husky
+  num_traces: 1000
+  show_plot: True
+  plot_traces: 100
+  trace_image_filename: projects/sample_traces_kmac.html
+  trace_db: ot_trace_library
+  trace_threshold: 10000
+test:
+  # which_test: kmac_random
+  # which_test: kmac_fvsr_key
+  which_test: kmac_fvsr_key_batch
+  key_len_bytes: 16
+  key_fixed: [0x81, 0x1E, 0x37, 0x31, 0xB0, 0x12, 0x0A, 0x78, 0x42, 0x78, 0x1E, 0x22, 0xB2, 0x5C, 0xDD, 0xF9]
+  text_len_bytes: 16
+  text_fixed: [0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA]
+  # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
+  # For unprotected implemetation, lfsr_seed should be set to 0. This will
+  # effectively switch off the masking. For masked implementation, any seed
+  # other than 0 should be used.
+  # w/o DOM
+  #lfsr_seed: 0
+  # w/ DOM
+  lfsr_seed: 0xdeadbeef
+  # seed for PRNG to generate sequence of plaintexts and keys; Python random class on host, Mersenne twister implementation on OT SW
+  batch_prng_seed: 0

--- a/ci/cfg/ci_kmac_sca_random_cw310_simpleserial.yaml
+++ b/ci/cfg/ci_kmac_sca_random_cw310_simpleserial.yaml
@@ -1,0 +1,59 @@
+target:
+  target_type: cw310
+  fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
+  force_program_bitstream: False
+  fw_bin: ../objs/kmac_serial_fpga_cw310.bin
+  # fw_bin: "../objs/kmac_ujson_fpga_cw310.bin"
+  # target_clk_mult is a hardcoded value in the bitstream. Do not change.
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  output_len_bytes: 32
+  protocol: "simpleserial"
+  # protocol: "ujson"
+  # port: "/dev/ttyACM_CW310_1"
+husky:
+  sampling_rate: 200000000
+  num_segments: 1
+  # Number of target clock cycles per trace - KMAC is doing 24 or 96 cycles
+  # for the key absorb w/o or w/ DOM, respectively, as well as 23 cycles for
+  # XORing the key into the state.
+  # w/o DOM
+  #num_cycles: 80
+  # w/ DOM
+  num_cycles: 160
+  # Offset in target clock cycles - During the first activity block, KMAC
+  # just absorbs the fixed prefix (23 cycles XORing + 24 or 96 cycles
+  # absorbing w/o or w/ DOM, respectively). This first activity block can be
+  # skipped
+  # w/o DOM
+  #offset_cyles: 43
+  # w/ DOM
+  offset_cycles: 115
+  scope_gain: 26
+capture:
+  scope_select: husky
+  num_traces: 1000
+  show_plot: True
+  plot_traces: 100
+  trace_image_filename: projects/sample_traces_kmac.html
+  trace_db: ot_trace_library
+  trace_threshold: 10000
+test:
+  which_test: kmac_random
+  # which_test: kmac_fvsr_key
+  # which_test: kmac_fvsr_key_batch
+  key_len_bytes: 16
+  key_fixed: [0x81, 0x1E, 0x37, 0x31, 0xB0, 0x12, 0x0A, 0x78, 0x42, 0x78, 0x1E, 0x22, 0xB2, 0x5C, 0xDD, 0xF9]
+  text_len_bytes: 16
+  text_fixed: [0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA]
+  # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
+  # For unprotected implemetation, lfsr_seed should be set to 0. This will
+  # effectively switch off the masking. For masked implementation, any seed
+  # other than 0 should be used.
+  # w/o DOM
+  #lfsr_seed: 0
+  # w/ DOM
+  lfsr_seed: 0xdeadbeef
+  # seed for PRNG to generate sequence of plaintexts and keys; Python random class on host, Mersenne twister implementation on OT SW
+  batch_prng_seed: 0

--- a/ci/cfg/ci_kmac_sca_random_cw310_ujson.yaml
+++ b/ci/cfg/ci_kmac_sca_random_cw310_ujson.yaml
@@ -1,0 +1,59 @@
+target:
+  target_type: cw310
+  fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
+  force_program_bitstream: False
+  # fw_bin: ../objs/kmac_serial_fpga_cw310.bin
+  fw_bin: "../objs/kmac_ujson_fpga_cw310.bin"
+  # target_clk_mult is a hardcoded value in the bitstream. Do not change.
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  output_len_bytes: 32
+  # protocol: "simpleserial"
+  protocol: "ujson"
+  port: "/dev/ttyACM_CW310_1"
+husky:
+  sampling_rate: 200000000
+  num_segments: 1
+  # Number of target clock cycles per trace - KMAC is doing 24 or 96 cycles
+  # for the key absorb w/o or w/ DOM, respectively, as well as 23 cycles for
+  # XORing the key into the state.
+  # w/o DOM
+  #num_cycles: 80
+  # w/ DOM
+  num_cycles: 160
+  # Offset in target clock cycles - During the first activity block, KMAC
+  # just absorbs the fixed prefix (23 cycles XORing + 24 or 96 cycles
+  # absorbing w/o or w/ DOM, respectively). This first activity block can be
+  # skipped
+  # w/o DOM
+  #offset_cyles: 43
+  # w/ DOM
+  offset_cycles: 115
+  scope_gain: 26
+capture:
+  scope_select: husky
+  num_traces: 1000
+  show_plot: True
+  plot_traces: 100
+  trace_image_filename: projects/sample_traces_kmac.html
+  trace_db: ot_trace_library
+  trace_threshold: 10000
+test:
+  which_test: kmac_random
+  # which_test: kmac_fvsr_key
+  # which_test: kmac_fvsr_key_batch
+  key_len_bytes: 16
+  key_fixed: [0x81, 0x1E, 0x37, 0x31, 0xB0, 0x12, 0x0A, 0x78, 0x42, 0x78, 0x1E, 0x22, 0xB2, 0x5C, 0xDD, 0xF9]
+  text_len_bytes: 16
+  text_fixed: [0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA]
+  # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
+  # For unprotected implemetation, lfsr_seed should be set to 0. This will
+  # effectively switch off the masking. For masked implementation, any seed
+  # other than 0 should be used.
+  # w/o DOM
+  #lfsr_seed: 0
+  # w/ DOM
+  lfsr_seed: 0xdeadbeef
+  # seed for PRNG to generate sequence of plaintexts and keys; Python random class on host, Mersenne twister implementation on OT SW
+  batch_prng_seed: 0

--- a/objs/kmac_ujson_fpga_cw310.bin
+++ b/objs/kmac_ujson_fpga_cw310.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3fa15e2be37805e666b30f4258695a13ee0523a374f3004360329b30507a3d3
+size 70064

--- a/util/data_generator.py
+++ b/util/data_generator.py
@@ -2,9 +2,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
 from Crypto.Cipher import AES
 from Crypto.Hash import KMAC128
+
+"""Data generator.
+
+Generates crypto material for the SCA tests.
+
+Input and output data format of the crypto material (ciphertext, plaintext,
+and key) is plain integer arrays.
+"""
 
 
 class data_generator():
@@ -37,17 +44,24 @@ class data_generator():
                            0x53, 0x53, 0x53, 0x53, 0x53, 0x53, 0x53, 0x53]
 
     def advance_fixed(self):
-        self.text_fixed = self.cipher_gen.encrypt(bytes(self.text_fixed))
+        text_fixed_bytes = self.cipher_gen.encrypt(bytes(self.text_fixed))
+        # Convert bytearray into int array.
+        self.text_fixed = [x for x in text_fixed_bytes]
 
     def advance_random(self):
-        self.text_random = self.cipher_gen.encrypt(bytes(self.text_random))
-        self.key_random = self.cipher_gen.encrypt(bytes(self.key_random))
+        text_random_bytes = self.cipher_gen.encrypt(bytes(self.text_random))
+        # Convert bytearray into int array.
+        self.text_random = [x for x in text_random_bytes]
+        key_random_bytes = self.cipher_gen.encrypt(bytes(self.key_random))
+        # Convert bytearray into int array.
+        self.key_random = [x for x in key_random_bytes]
 
     def get_fixed(self):
         pt = self.text_fixed
         key = self.key_fixed
         cipher_fixed = AES.new(bytes(self.key_fixed), AES.MODE_ECB)
-        ct = cipher_fixed.encrypt(bytes(self.text_fixed))
+        ct_bytes = cipher_fixed.encrypt(bytes(self.text_fixed))
+        ct = [x for x in ct_bytes]
         del (cipher_fixed)
         self.advance_fixed()
         return pt, ct, key
@@ -56,27 +70,30 @@ class data_generator():
         pt = self.text_random
         key = self.key_random
         cipher_random = AES.new(bytes(self.key_random), AES.MODE_ECB)
-        ct = cipher_random.encrypt(bytes(self.text_random))
+        ct_bytes = cipher_random.encrypt(bytes(self.text_random))
+        ct = [x for x in ct_bytes]
         del (cipher_random)
         self.advance_random()
         return pt, ct, key
 
     def get_kmac_fixed(self):
-        pt = np.asarray(self.text_fixed)
-        key = np.asarray(self.key_fixed)
+        pt = self.text_fixed
+        key = self.key_fixed
         mac_fixed = KMAC128.new(key=bytes(self.key_fixed), mac_len=32)
         mac_fixed.update(bytes(self.text_fixed))
-        ct = np.asarray(bytearray(mac_fixed.digest()))
+        ct_bytes = mac_fixed.digest()
+        ct = [x for x in ct_bytes]
         del (mac_fixed)
         self.advance_fixed()
         return pt, ct, key
 
     def get_kmac_random(self):
-        pt = np.asarray(self.text_random)
-        key = np.asarray(self.key_random)
+        pt = self.text_random
+        key = self.key_random
         mac_random = KMAC128.new(key=bytes(self.key_random), mac_len=32)
         mac_random.update(bytes(self.text_random))
-        ct = np.asarray(bytearray(mac_random.digest()))
+        ct_bytes = mac_random.digest()
+        ct = [x for x in ct_bytes]
 
         del (mac_random)
         self.advance_random()


### PR DESCRIPTION
Similar to #218 , this PR enables uJSON support for capturing KMAC traces. The device command handler code can be found in [#20563](https://github.com/lowRISC/opentitan/pull/20563).

Consists of three commits:
- uJSON implementation. Closes #238
- Adds KMAC to CI. Closes #237 
- Switch byte array to int array in data generator.