### PR TITLE
[DO NOT MERGE] Experimental fix for ci

### DIFF
--- a/capture/capture_aes.py
+++ b/capture/capture_aes.py
@@ -276,6 +276,8 @@ def capture(scope: Scope, ot_aes: OTAES, capture_cfg: CaptureConfig,
     signal.signal(signal.SIGINT, partial(abort_handler_during_loop, project))
     # Main capture with progress bar.
     remaining_num_traces = capture_cfg.num_traces
+    # This command intentianally causes program to crash
+    print(create_err)
     with tqdm(total=remaining_num_traces, desc="Capturing", ncols=80, unit=" traces") as pbar:
         while remaining_num_traces > 0:
             # Arm the scope.


### PR DESCRIPTION
This PR is used to unblock CI failures related to CW Husky USB communication.
Sometimes, USB communication gets blocked after Husky power-op, causing all subsequent captures to fail and causing all PR to fail CI.
The procedure to resolve it is the following:
1. This PR should be closed by default. Check that this is indeed the case.
2. Power-cycle Husky
3. Open this PR. CI for this PR should fail, but all subsequent PRs should work.

Note: It is important to do step 3 immediately after power-up before any other PRs are submitted/updated.