### PR TITLE
[capture] Enable uJSON for SHA3

### DIFF
--- a/capture/configs/sha3_sca_cw310.yaml
+++ b/capture/configs/sha3_sca_cw310.yaml
@@ -3,11 +3,14 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: ../objs/sha3_serial_fpga_cw310.bin
+  # fw_bin: ../objs/sha3_ujson_fpga_cw310.bin
   target_clk_mult: 0.24
   target_freq: 24000000
   baudrate: 115200
   output_len_bytes: 32
   protocol: "simpleserial"
+  # protocol: "ujson"
+  # port: "/dev/ttyACM4"
 husky:
   samling_rate: 200000000
   num_segments: 20
@@ -25,7 +28,6 @@ capture:
   num_traces: 5000
   show_plot: True
   plot_traces: 100
-  trace_image_filename: projects/sample_traces_sha3.html
   trace_db: ot_trace_library
   trace_threshold: 10000
 test:

--- a/capture/configs/sha3_sca_cw310_masks_off.yaml
+++ b/capture/configs/sha3_sca_cw310_masks_off.yaml
@@ -3,11 +3,14 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: ../objs/sha3_serial_fpga_cw310.bin
+  # fw_bin: ../objs/sha3_ujson_fpga_cw310.bin
   target_clk_mult: 0.24
   target_freq: 24000000
   baudrate: 115200
   output_len_bytes: 32
   protocol: "simpleserial"
+  # protocol: "ujson"
+  # port: "/dev/ttyACM4"
 husky:
   samling_rate: 200000000
   num_segments: 20
@@ -25,7 +28,6 @@ capture:
   num_traces: 5000
   show_plot: True
   plot_traces: 100
-  trace_image_filename: projects/sample_traces_sha3.html
   trace_db: ot_trace_library
   trace_threshold: 10000
 test:

--- a/capture/lib/ot_communication.py
+++ b/capture/lib/ot_communication.py
@@ -39,7 +39,7 @@ class OTAES:
 
     def _ujson_aes_sca_cmd(self):
         # TODO: without the delay, the device uJSON command handler program
-        # does not recognize the commands.
+        # does not recognize the commands. Tracked in issue #256.
         time.sleep(0.01)
         self.port.write(json.dumps("AesSca").encode("ascii"))
 
@@ -291,7 +291,7 @@ class OTKMAC:
 
     def _ujson_kmac_sca_cmd(self):
         # TODO: without the delay, the device uJSON command handler program
-        # does not recognize the commands.
+        # does not recognize the commands. Tracked in issue #256.
         time.sleep(0.01)
         self.port.write(json.dumps("KmacSca").encode("ascii"))
 
@@ -420,7 +420,7 @@ class OTSHA3:
 
     def _ujson_sha_sca_cmd(self):
         # TODO: without the delay, the device uJSON command handler program
-        # does not recognize the commands.
+        # does not recognize the commands. Tracked in issue #256.
         time.sleep(0.01)
         self.port.write(json.dumps("ShaSca").encode("ascii"))
 
@@ -433,12 +433,12 @@ class OTSHA3:
                 try:
                     status = json.loads(json_string)["status"]
                     if status[0] != 0:
-                        raise Exception("Batch mode acknowledge error: Device and host not in sync")
+                        raise Exception("Acknowledge error: Device and host not in sync")
                     return status
                 except Exception:
-                    raise Exception("Batch mode acknowledge error: Device and host not in sync")
+                    raise Exception("Acknowledge error: Device and host not in sync")
             else:
-                raise Exception("Batch mode acknowledge error: Device and host not in sync")
+                raise Exception("Acknowledge error: Device and host not in sync")
 
     def set_mask_off(self):
         if self.simple_serial:

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -58,6 +58,64 @@ jobs:
       ./ci_trace_check/ci_compare_aes_traces.py -f ./projects/aes_sca_random_cw310 -g ./ci_trace_check/golden_traces/aes_sca_random_golden_cw310 -c 0.8
       popd
     displayName: "Compare AES Random Key traces against golden trace"
+- job: sha3_sca_capture_cw310
+  displayName: "Capture SHA3 SCA traces (CW310)"
+  timeoutInMinutes: 30
+  pool:
+    name: FPGA SCA
+    demands: BOARD -equals cw310
+  steps:
+  - checkout: self
+  - bash: |
+      python3 -m pip install --user -r python-requirements.txt
+    displayName: "Install python dependencies"
+  - bash: |
+      apt update
+      apt install git-lfs
+    displayName: "Install system dependencies"
+  - bash: |
+      git-lfs pull
+    displayName: "Pull LFS binaries"
+  - bash: |
+      set -e
+      pushd ci
+      mkdir -p projects
+      ../capture/capture_sha3.py -c cfg/ci_sha3_sca_fvsr_cw310_simpleserial.yaml -p projects/sha3_sca_fvsr_cw310_simpleserial
+      popd
+    displayName: "Capture SHA3 FVSR traces (simpleserial)"
+  - publish: ./ci/projects/sha3_sca_fvsr_cw310_simpleserial.html
+    artifact: traces_sha3_fvsr_cw310_simpleserial
+    displayName: "Upload SHA3 FVSR traces (simpleserial)"
+  - bash: |
+      set -e
+      pushd ci
+      mkdir -p projects
+      ../capture/capture_sha3.py -c cfg/ci_sha3_sca_fvsr_cw310_ujson.yaml -p projects/sha3_sca_fvsr_cw310_ujson
+      popd
+    displayName: "Capture SHA3 FVSR traces (uJSON)"
+  - publish: ./ci/projects/sha3_sca_fvsr_cw310_ujson.html
+    artifact: traces_sha3_fvsr_cw310_ujson
+    displayName: "Upload SHA3 FVSR traces (uJSON)"
+  - bash: |
+      set -e
+      pushd ci
+      mkdir -p projects
+      ../capture/capture_sha3.py -c cfg/ci_sha3_sca_random_cw310_simpleserial.yaml -p projects/sha3_sca_random_cw310_simpleserial
+      popd
+    displayName: "Capture SHA3 Random traces (simpleserial)"
+  - publish: ./ci/projects/sha3_sca_random_cw310_simpleserial.html
+    artifact: traces_sha3_random_cw310_simpleserial
+    displayName: "Upload SHA3 Random traces (simpleserial)"
+  - bash: |
+      set -e
+      pushd ci
+      mkdir -p projects
+      ../capture/capture_sha3.py -c cfg/ci_sha3_sca_random_cw310_ujson.yaml -p projects/sha3_sca_random_cw310_ujson
+      popd
+    displayName: "Capture SHA3 Random traces (uJSON)"
+  - publish: ./ci/projects/sha3_sca_random_cw310_ujson.html
+    artifact: traces_sha3_random_cw310_ujson
+    displayName: "Upload SHA3 Random traces (uJSON)"
 - job: sca_capture_cw305
   displayName: "Capture AES SCA traces (CW305)"
   timeoutInMinutes: 30

--- a/ci/cfg/ci_sha3_sca_fvsr_cw310_simpleserial.yaml
+++ b/ci/cfg/ci_sha3_sca_fvsr_cw310_simpleserial.yaml
@@ -1,0 +1,53 @@
+target:
+  target_type: cw310
+  fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
+  force_program_bitstream: False
+  fw_bin: ../objs/sha3_serial_fpga_cw310.bin
+  # fw_bin: ../objs/sha3_ujson_fpga_cw310.bin
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  output_len_bytes: 32
+  protocol: "simpleserial"
+  # protocol: "ujson"
+  # port: "/dev/ttyACM4"
+husky:
+  samling_rate: 200000000
+  num_segments: 20
+  # Number of target clock cycles per trace - SHA3 with DOM is doing 120
+  # cycles (24 for loading and padding, 96 for processing) with 320 delay
+  # cycles between loading the plaintext and adding the padding. The plaintext
+  # loading and the delay cycles can be ignored.
+  num_cycles: 125
+  offset_cycles: 320
+  scope_gain: 27
+capture:
+  scope_select: husky
+  #key_len_bytes: 16
+  plain_text_len_bytes: 16
+  num_traces: 100
+  show_plot: True
+  plot_traces: 100
+  trace_db: ot_trace_library
+  trace_threshold: 10000
+test:
+  # which_test: sha3_random
+  # which_test: sha3_fvsr_data
+  which_test: sha3_fvsr_data_batch
+  # Switch the masking on or off. When off, messages aren't masked upon loading
+  # into the SHA3 core and the PRNG isn't advanced during SHA3 processing.
+  # Works for SHA3 only. Doesn't work when processing key material.
+  masks_off: true
+  text_len_bytes: 16
+  text_fixed: [0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA]
+  # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
+  # For unprotected implemetation, lfsr_seed should be set to 0. This will
+  # effectively switch off the masking. For masked implementation, any seed
+  # other than 0 should be used.
+  # w/o DOM
+  #lfsr_seed: 0
+  # w/ DOM
+  # 32-bit LFSR seed - Currently not used by the target for SHA3 captures.
+  lfsr_seed: 0xdeadbeef
+  # seed for PRNG to generate sequence of plaintexts and keys; Python random class on host, Mersenne twister implementation on OT SW
+  batch_prng_seed: 0

--- a/ci/cfg/ci_sha3_sca_fvsr_cw310_ujson.yaml
+++ b/ci/cfg/ci_sha3_sca_fvsr_cw310_ujson.yaml
@@ -1,0 +1,53 @@
+target:
+  target_type: cw310
+  fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
+  force_program_bitstream: False
+  # fw_bin: ../objs/sha3_serial_fpga_cw310.bin
+  fw_bin: ../objs/sha3_ujson_fpga_cw310.bin
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  output_len_bytes: 32
+  # protocol: "simpleserial"
+  protocol: "ujson"
+  port: "/dev/ttyACM_CW310_1"
+husky:
+  samling_rate: 200000000
+  num_segments: 20
+  # Number of target clock cycles per trace - SHA3 with DOM is doing 120
+  # cycles (24 for loading and padding, 96 for processing) with 320 delay
+  # cycles between loading the plaintext and adding the padding. The plaintext
+  # loading and the delay cycles can be ignored.
+  num_cycles: 125
+  offset_cycles: 320
+  scope_gain: 27
+capture:
+  scope_select: husky
+  #key_len_bytes: 16
+  plain_text_len_bytes: 16
+  num_traces: 100
+  show_plot: True
+  plot_traces: 100
+  trace_db: ot_trace_library
+  trace_threshold: 10000
+test:
+  # which_test: sha3_random
+  # which_test: sha3_fvsr_data
+  which_test: sha3_fvsr_data_batch
+  # Switch the masking on or off. When off, messages aren't masked upon loading
+  # into the SHA3 core and the PRNG isn't advanced during SHA3 processing.
+  # Works for SHA3 only. Doesn't work when processing key material.
+  masks_off: true
+  text_len_bytes: 16
+  text_fixed: [0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA]
+  # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
+  # For unprotected implemetation, lfsr_seed should be set to 0. This will
+  # effectively switch off the masking. For masked implementation, any seed
+  # other than 0 should be used.
+  # w/o DOM
+  #lfsr_seed: 0
+  # w/ DOM
+  # 32-bit LFSR seed - Currently not used by the target for SHA3 captures.
+  lfsr_seed: 0xdeadbeef
+  # seed for PRNG to generate sequence of plaintexts and keys; Python random class on host, Mersenne twister implementation on OT SW
+  batch_prng_seed: 0

--- a/ci/cfg/ci_sha3_sca_random_cw310_simpleserial.yaml
+++ b/ci/cfg/ci_sha3_sca_random_cw310_simpleserial.yaml
@@ -1,0 +1,53 @@
+target:
+  target_type: cw310
+  fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
+  force_program_bitstream: False
+  fw_bin: ../objs/sha3_serial_fpga_cw310.bin
+  # fw_bin: ../objs/sha3_ujson_fpga_cw310.bin
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  output_len_bytes: 32
+  protocol: "simpleserial"
+  # protocol: "ujson"
+  # port: "/dev/ttyACM4"
+husky:
+  samling_rate: 200000000
+  num_segments: 1
+  # Number of target clock cycles per trace - SHA3 with DOM is doing 120
+  # cycles (24 for loading and padding, 96 for processing) with 320 delay
+  # cycles between loading the plaintext and adding the padding. The plaintext
+  # loading and the delay cycles can be ignored.
+  num_cycles: 125
+  offset_cycles: 320
+  scope_gain: 27
+capture:
+  scope_select: husky
+  #key_len_bytes: 16
+  plain_text_len_bytes: 16
+  num_traces: 100
+  show_plot: True
+  plot_traces: 100
+  trace_db: ot_trace_library
+  trace_threshold: 10000
+test:
+  which_test: sha3_random
+  # which_test: sha3_fvsr_data
+  # which_test: sha3_fvsr_data_batch
+  # Switch the masking on or off. When off, messages aren't masked upon loading
+  # into the SHA3 core and the PRNG isn't advanced during SHA3 processing.
+  # Works for SHA3 only. Doesn't work when processing key material.
+  masks_off: true
+  text_len_bytes: 16
+  text_fixed: [0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA]
+  # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
+  # For unprotected implemetation, lfsr_seed should be set to 0. This will
+  # effectively switch off the masking. For masked implementation, any seed
+  # other than 0 should be used.
+  # w/o DOM
+  #lfsr_seed: 0
+  # w/ DOM
+  # 32-bit LFSR seed - Currently not used by the target for SHA3 captures.
+  lfsr_seed: 0xdeadbeef
+  # seed for PRNG to generate sequence of plaintexts and keys; Python random class on host, Mersenne twister implementation on OT SW
+  batch_prng_seed: 0

--- a/ci/cfg/ci_sha3_sca_random_cw310_ujson.yaml
+++ b/ci/cfg/ci_sha3_sca_random_cw310_ujson.yaml
@@ -1,0 +1,53 @@
+target:
+  target_type: cw310
+  fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
+  force_program_bitstream: False
+  # fw_bin: ../objs/sha3_serial_fpga_cw310.bin
+  fw_bin: ../objs/sha3_ujson_fpga_cw310.bin
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  output_len_bytes: 32
+  # protocol: "simpleserial"
+  protocol: "ujson"
+  port: "/dev/ttyACM_CW310_1"
+husky:
+  samling_rate: 200000000
+  num_segments: 1
+  # Number of target clock cycles per trace - SHA3 with DOM is doing 120
+  # cycles (24 for loading and padding, 96 for processing) with 320 delay
+  # cycles between loading the plaintext and adding the padding. The plaintext
+  # loading and the delay cycles can be ignored.
+  num_cycles: 125
+  offset_cycles: 320
+  scope_gain: 27
+capture:
+  scope_select: husky
+  #key_len_bytes: 16
+  plain_text_len_bytes: 16
+  num_traces: 100
+  show_plot: True
+  plot_traces: 100
+  trace_db: ot_trace_library
+  trace_threshold: 10000
+test:
+  which_test: sha3_random
+  # which_test: sha3_fvsr_data
+  # which_test: sha3_fvsr_data_batch
+  # Switch the masking on or off. When off, messages aren't masked upon loading
+  # into the SHA3 core and the PRNG isn't advanced during SHA3 processing.
+  # Works for SHA3 only. Doesn't work when processing key material.
+  masks_off: true
+  text_len_bytes: 16
+  text_fixed: [0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA]
+  # 32-bit seed for SW key masking. Key masks are generated using an LFSR.
+  # For unprotected implemetation, lfsr_seed should be set to 0. This will
+  # effectively switch off the masking. For masked implementation, any seed
+  # other than 0 should be used.
+  # w/o DOM
+  #lfsr_seed: 0
+  # w/ DOM
+  # 32-bit LFSR seed - Currently not used by the target for SHA3 captures.
+  lfsr_seed: 0xdeadbeef
+  # seed for PRNG to generate sequence of plaintexts and keys; Python random class on host, Mersenne twister implementation on OT SW
+  batch_prng_seed: 0

--- a/objs/sha3_ujson_fpga_cw310.bin
+++ b/objs/sha3_ujson_fpga_cw310.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c999d1dfb097edac3ee5cb7bc4eebba8e9c8ad21d02c6f01fa61b0fedd5ee6d5
+size 70712

--- a/util/data_generator.py
+++ b/util/data_generator.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
 from Crypto.Cipher import AES
 from Crypto.Hash import KMAC128, SHA3_256
 
@@ -101,19 +100,22 @@ class data_generator():
         return pt, ct, key
 
     def get_sha3_fixed(self):
-        pt = np.asarray(bytearray(self.text_fixed))
-        key = np.asarray(self.key_fixed)
+        pt = self.text_fixed
+        key = self.key_fixed
         sha3_fixed = SHA3_256.new(bytes(self.text_fixed))
-        ct = np.asarray(bytearray(sha3_fixed.digest()))
+        ct_bytes = sha3_fixed.digest()
+        ct = [x for x in ct_bytes]
+
         del (sha3_fixed)
         self.advance_fixed()
         return pt, ct, key
 
     def get_sha3_random(self):
-        pt = np.asarray(bytearray(self.text_random))
-        key = np.asarray(self.key_random)
+        pt = self.text_random
+        key = self.key_random
         sha3_random = SHA3_256.new(bytes(self.text_random))
-        ct = np.asarray(bytearray(sha3_random.digest()))
+        ct_bytes = sha3_random.digest()
+        ct = [x for x in ct_bytes]
 
         del (sha3_random)
         self.advance_random()


### PR DESCRIPTION
Similar to #218 , this PR enables uJSON support for capturing SHA3
traces. The device command handler code can be found in [#20593](https://github.com/lowRISC/opentitan/pull/20593).