### PR TITLE
[fi] Deterministic parameter generation

### DIFF
--- a/ci/cfg/ci_ibex_fi_vcc_dummy.yaml
+++ b/ci/cfg/ci_ibex_fi_vcc_dummy.yaml
@@ -12,6 +12,13 @@ target:
 fisetup:
   fi_gear: "dummy"
   fi_type: "voltage_glitch"
+  # Parameter generation.
+  parameter_generation: "random"
+  # Number of randomized iterations for the parameter sweep.
+  # For parameter_generation: "random", this is the number of iterations.
+  # For parameter_generation: "deterministic", this is the number of iterations
+  # per fixed parameter.
+  num_iterations: 100
   # Voltage glitch width in ns.
   glitch_voltage_min: 2.7
   glitch_voltage_max: 3.3
@@ -24,8 +31,6 @@ fisetup:
   trigger_delay_min: 0
   trigger_delay_max: 500
   trigger_step: 10
-  # Number of iterations for the parameter sweep.
-  num_iterations: 100
 fiproject:
   # Project database type and memory threshold.
   project_db: "ot_fi_project"

--- a/fault_injection/configs/pen.global_fi.ibex.char.unrolled_reg_op_loop.yaml
+++ b/fault_injection/configs/pen.global_fi.ibex.char.unrolled_reg_op_loop.yaml
@@ -12,6 +12,13 @@ target:
 fisetup:
   fi_gear: "husky"
   fi_type: "voltage_glitch"
+  # Parameter generation.
+  parameter_generation: "random"
+  # Number of randomized iterations for the parameter sweep.
+  # For parameter_generation: "random", this is the number of iterations.
+  # For parameter_generation: "deterministic", this is the number of iterations
+  # per fixed parameter.
+  num_iterations: 10000
   # Voltage glitch width in cycles.
   glitch_width_min: 5
   glitch_width_max: 150
@@ -20,8 +27,6 @@ fisetup:
   trigger_delay_min: 0
   trigger_delay_max: 500
   trigger_step: 10
-  # Number of iterations for the parameter sweep.
-  num_iterations: 10000
 fiproject:
   # Project database type and memory threshold.
   project_db: "ot_fi_project"

--- a/fault_injection/fi_gear/dummy/dummy_vcc.py
+++ b/fault_injection/fi_gear/dummy/dummy_vcc.py
@@ -13,7 +13,9 @@ class DummyVCC:
     def __init__(self, glitch_voltage_min: float, glitch_voltage_max: float,
                  glitch_voltage_step: float, glitch_width_min: float,
                  glitch_width_max: float, glitch_width_step: float,
-                 trigger_delay_min: int, trigger_delay_max: int, trigger_step: int):
+                 trigger_delay_min: int, trigger_delay_max: int,
+                 trigger_step: int, num_iterations: int,
+                 parameter_generation: str):
         self.glitch_voltage_min = glitch_voltage_min
         self.glitch_voltage_max = glitch_voltage_max
         self.glitch_voltage_step = glitch_voltage_step
@@ -23,6 +25,8 @@ class DummyVCC:
         self.trigger_delay_min = trigger_delay_min
         self.trigger_delay_max = trigger_delay_max
         self.trigger_step = trigger_step
+        self.num_iterations = num_iterations
+        self.parameter_generation = parameter_generation
 
     def arm_trigger(self, fault_parameters: dict) -> None:
         """ Arm the trigger.
@@ -39,19 +43,34 @@ class DummyVCC:
         Returns:
             A dict containing the FI parameters.
         """
-        parameters = {}
-        parameters["glitch_voltage"] = random_float_range(self.glitch_voltage_min,
-                                                          self.glitch_voltage_max,
-                                                          self.glitch_voltage_step)
-        parameters["glitch_width"] = random_float_range(self.glitch_width_min,
-                                                        self.glitch_width_max,
-                                                        self.glitch_width_step)
-        parameters["trigger_delay"] = random_float_range(self.trigger_delay_min,
-                                                         self.trigger_delay_max,
-                                                         self.trigger_step)
+        if self.parameter_generation == "random":
+            parameters = {}
+            parameters["glitch_voltage"] = random_float_range(self.glitch_voltage_min,
+                                                              self.glitch_voltage_max,
+                                                              self.glitch_voltage_step)
+            parameters["glitch_width"] = random_float_range(self.glitch_width_min,
+                                                            self.glitch_width_max,
+                                                            self.glitch_width_step)
+            parameters["trigger_delay"] = random_float_range(self.trigger_delay_min,
+                                                             self.trigger_delay_max,
+                                                             self.trigger_step)
+        else:
+            raise Exception("DummyVCC only supports random parameter generation")
+
         return parameters
 
     def reset(self) -> None:
         """ No reset is required for dummy VCC glitch gear.
         """
         pass
+
+    def get_num_fault_injections(self) -> int:
+        """ Get number of fault injections.
+
+        Returns: The total number of fault injections performed with the
+                DummyVCCFI gear.
+        """
+        if self.parameter_generation == "random":
+            return self.num_iterations
+        else:
+            raise Exception("DummyVCC only supports random parameter generation")

--- a/fault_injection/fi_gear/fi_gear.py
+++ b/fault_injection/fi_gear/fi_gear.py
@@ -27,7 +27,9 @@ class FIGear:
                 glitch_width_step = cfg["fisetup"]["glitch_width_step"],
                 trigger_delay_min = cfg["fisetup"]["trigger_delay_min"],
                 trigger_delay_max = cfg["fisetup"]["trigger_delay_max"],
-                trigger_step = cfg["fisetup"]["trigger_step"])
+                trigger_step = cfg["fisetup"]["trigger_step"],
+                num_iterations = cfg["fisetup"]["num_iterations"],
+                parameter_generation = cfg["fisetup"]["parameter_generation"])
         elif self.gear_type == "husky" and self.fi_type == "voltage_glitch":
             self.gear = HuskyVCC(
                 pll_frequency = cfg["target"]["pll_frequency"],
@@ -36,7 +38,9 @@ class FIGear:
                 glitch_width_step = cfg["fisetup"]["glitch_width_step"],
                 trigger_delay_min = cfg["fisetup"]["trigger_delay_min"],
                 trigger_delay_max = cfg["fisetup"]["trigger_delay_max"],
-                trigger_step = cfg["fisetup"]["trigger_step"])
+                trigger_step = cfg["fisetup"]["trigger_step"],
+                num_iterations = cfg["fisetup"]["num_iterations"],
+                parameter_generation = cfg["fisetup"]["parameter_generation"])
 
     def arm_trigger(self, fi_parameters: dict) -> None:
         """ Arm the trigger.
@@ -58,6 +62,12 @@ class FIGear:
         """ Reset the FI gear.
 
         Some FI gear (Husky) needs to be resettet.
-
         """
         self.gear.reset()
+
+    def get_num_fault_injections(self) -> int:
+        """ Get number of fault injections.
+
+        Returns: The total number of fault injections performed with the FI gear.
+        """
+        return self.gear.get_num_fault_injections()

--- a/fault_injection/fi_ibex.py
+++ b/fault_injection/fi_ibex.py
@@ -81,7 +81,7 @@ def fi_parameter_sweep(cfg: dict, cwtarget: CWFPGA, fi_gear,
     # Configure the trigger.
     ot_communication.init_trigger()
     # Start the parameter sweep.
-    remaining_iterations = cfg["fisetup"]["num_iterations"]
+    remaining_iterations = fi_gear.get_num_fault_injections()
     with tqdm(total=remaining_iterations, desc="Injecting", ncols=80,
               unit=" different faults") as pbar:
         while remaining_iterations > 0:


### PR DESCRIPTION
This PR extends the existing FI setup to generate FI parameters deterministically. This is helpful for certain gear where a random parameter generation is not meaningfull (e.g., X/Y table for LFI).

Each FI gear needs to implement the deterministic parameter generation by themselves. This PR extends the Husky VCC glitcher to either randomly or deterministically generate the paramters.

Closes #253.