### PR TITLE
[fi] Add templates for EM/LFI & clk glitching

### DIFF
--- a/fault_injection/fi_gear/dummy/README.md
+++ b/fault_injection/fi_gear/dummy/README.md
@@ -1,0 +1,14 @@
+# Template drivers for FI gear
+
+This directory includes dummy drivers for FI gear that can be used as a
+template to create new drivers.
+All drivers need to implement these functions:
+- init:
+    - Initializes the FI gear.
+- generate_fi_parameters:
+    - Generate parameters for the FI parameter sweep. This can happen either
+      randomly or deterministically.
+- arm_trigger:
+    - Configure the FI gear with the current FI parameters and arm the trigger.
+- reset:
+    - After a power cycle of the DUT, some FI gear also needs to be reset.

--- a/fault_injection/fi_gear/dummy/dummy_clk.py
+++ b/fault_injection/fi_gear/dummy/dummy_clk.py
@@ -1,0 +1,64 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from fi_gear.utility import random_float_range
+
+""" Template for CLK glitching gear.
+Acts as a template for clock glitching FI gear.
+"""
+
+
+class DummyCLK:
+    def __init__(self, glitch_width_min: int, glitch_width_max: int,
+                 glitch_width_step: int, trigger_delay_min: int,
+                 trigger_delay_max: int, trigger_step: int,
+                 num_iterations: int, parameter_generation: str):
+        self.glitch_width_min = glitch_width_min
+        self.glitch_width_max = glitch_width_max
+        self.glitch_width_step = glitch_width_step
+        self.trigger_delay_min = trigger_delay_min
+        self.trigger_delay_max = trigger_delay_max
+        self.trigger_step = trigger_step
+        self.num_iterations = num_iterations
+        self.parameter_generation = parameter_generation
+
+    def arm_trigger(self, fault_parameters: dict) -> None:
+        """ Arm the trigger.
+
+        Args:
+            A dict containing the FI parameters.
+        """
+        print(f"Arming DummyCLK trigger with"
+              f"glitch_width={fault_parameters['glitch_width']}, and "
+              f"trigger_delay={fault_parameters['trigger_delay']}")
+
+    def generate_fi_parameters(self) -> dict:
+        """ Generate clock glitching parameters within the provided limits.
+
+        Returns:
+            A dict containing the FI parameters.
+        """
+        parameters = {}
+        parameters["glitch_width"] = random_float_range(self.glitch_width_min,
+                                                        self.glitch_width_max,
+                                                        self.glitch_width_step)
+        parameters["trigger_delay"] = random_float_range(self.trigger_delay_min,
+                                                         self.trigger_delay_max,
+                                                         self.trigger_step)
+        return parameters
+
+    def reset(self) -> None:
+        """ No reset is required for dummy clock glitching FI gear.
+        """
+        pass
+
+    def get_num_fault_injections(self) -> int:
+        """ Get number of fault injections.
+
+        Returns: The total number of fault injections performed with DummyCLK.
+        """
+        if self.parameter_generation == "random":
+            return self.num_iterations
+        else:
+            raise Exception("DummyCLK only supports random parameter generation")

--- a/fault_injection/fi_gear/dummy/dummy_emfi.py
+++ b/fault_injection/fi_gear/dummy/dummy_emfi.py
@@ -1,0 +1,116 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from fi_gear.utility import random_float_range
+
+""" Template for EMFI gear.
+Acts as a template for electromagnetic FI gear with XY table.
+"""
+
+
+class DummyEMFI:
+    def __init__(self, x_position_min: int, x_position_max: int,
+                 x_position_step: int, y_position_min: int, y_position_max: int,
+                 y_position_step: int, voltage_min: int, voltage_max: int,
+                 voltage_step: int, pulse_width_min: int,
+                 pulse_width_max: int, pulse_width_step: int,
+                 trigger_delay_min: int, trigger_delay_max: int,
+                 trigger_step: int, num_iterations: int,
+                 parameter_generation: str):
+        self.x_position_min = x_position_min
+        self.x_position_max = x_position_max
+        self.x_position_step = x_position_step
+        self.y_position_min = y_position_min
+        self.y_position_max = y_position_max
+        self.y_position_step = y_position_step
+        self.voltage_min = voltage_min
+        self.voltage_max = voltage_max
+        self.voltage_step = voltage_step
+        self.pulse_width_min = pulse_width_min
+        self.pulse_width_max = pulse_width_max
+        self.pulse_width_step = pulse_width_step
+        self.trigger_delay_min = trigger_delay_min
+        self.trigger_delay_max = trigger_delay_max
+        self.trigger_step = trigger_step
+        self.num_iterations = num_iterations
+        self.parameter_generation = parameter_generation
+
+        # Current x & y position.
+        self.curr_x_position = self.x_position_min
+        self.curr_y_position = self.y_position_min
+
+        # Current FI parameter iteration.
+        self.curr_iteration = 0
+
+    def arm_trigger(self, fault_parameters: dict) -> None:
+        """ Arm the trigger.
+
+        Args:
+            A dict containing the FI parameters.
+        """
+        print(f"Arming DummyEMFI trigger with "
+              f"x_position={fault_parameters['x_position']} "
+              f"y_position={fault_parameters['y_position']}, "
+              f"voltage={fault_parameters['voltage']}, "
+              f"pulse_width={fault_parameters['pulse_width']}, and "
+              f"trigger_delay={fault_parameters['trigger_delay']}")
+
+    def generate_fi_parameters(self) -> dict:
+        """ Generate EMFI parameters within the provided limits.
+
+        Returns:
+            A dict containing the FI parameters.
+        """
+        parameters = {}
+        if self.parameter_generation == "random":
+            parameters["x_position"] = random_float_range(self.x_position_min,
+                                                          self.x_position_max,
+                                                          self.x_position_step)
+            parameters["y_position"] = random_float_range(self.y_position_min,
+                                                          self.y_position_max,
+                                                          self.y_position_step)
+        elif self.parameter_generation == "deterministic":
+            if self.curr_iteration == self.num_iterations:
+                self.curr_iteration = 0
+                if self.curr_y_position < self.y_position_max:
+                    self.curr_y_position += self.y_position_step
+                else:
+                    self.curr_y_position = self.y_position_min
+                    self.curr_x_position += self.x_position_step
+
+            parameters["x_position"] = self.curr_x_position
+            parameters["y_position"] = self.curr_y_position
+            self.curr_iteration += 1
+        else:
+            raise Exception("DummyEMFI only supports random/deterministic parameter generation")
+
+        parameters["voltage"] = random_float_range(self.voltage_min,
+                                                   self.voltage_max,
+                                                   self.voltage_step)
+        parameters["pulse_width"] = random_float_range(self.pulse_width_min,
+                                                       self.pulse_width_max,
+                                                       self.pulse_width_step)
+        parameters["trigger_delay"] = random_float_range(self.trigger_delay_min,
+                                                         self.trigger_delay_max,
+                                                         self.trigger_step)
+        return parameters
+
+    def reset(self) -> None:
+        """ No reset is required for dummy EMFI gear.
+        """
+        pass
+
+    def get_num_fault_injections(self) -> int:
+        """ Get number of fault injections.
+
+        Returns: The total number of fault injections performed with DummyEMFI.
+        """
+        if self.parameter_generation == "random":
+            return self.num_iterations
+        elif self.parameter_generation == "deterministic":
+            return ((self.x_position_max - self.x_position_min + 1) /
+                    self.x_position_step) * ((self.y_position_max - self.y_position_min + 1) /
+                                             self.y_position_step) * (self.num_iterations)
+        else:
+            raise Exception("DummyEMFI only supports random/deterministic parameter generation")

--- a/fault_injection/fi_gear/dummy/dummy_lfi.py
+++ b/fault_injection/fi_gear/dummy/dummy_lfi.py
@@ -1,0 +1,116 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from fi_gear.utility import random_float_range
+
+""" Template for LFI gear.
+Acts as a template for laser FI gear with XY table.
+"""
+
+
+class DummyLFI:
+    def __init__(self, x_position_min: int, x_position_max: int,
+                 x_position_step: int, y_position_min: int, y_position_max: int,
+                 y_position_step: int, attenuation_min: int, attenuation_max: int,
+                 attenuation_step: int, pulse_width_min: int,
+                 pulse_width_max: int, pulse_width_step: int,
+                 trigger_delay_min: int, trigger_delay_max: int,
+                 trigger_step: int, num_iterations: int,
+                 parameter_generation: str):
+        self.x_position_min = x_position_min
+        self.x_position_max = x_position_max
+        self.x_position_step = x_position_step
+        self.y_position_min = y_position_min
+        self.y_position_max = y_position_max
+        self.y_position_step = y_position_step
+        self.attenuation_min = attenuation_min
+        self.attenuation_max = attenuation_max
+        self.attenuation_step = attenuation_step
+        self.pulse_width_min = pulse_width_min
+        self.pulse_width_max = pulse_width_max
+        self.pulse_width_step = pulse_width_step
+        self.trigger_delay_min = trigger_delay_min
+        self.trigger_delay_max = trigger_delay_max
+        self.trigger_step = trigger_step
+        self.num_iterations = num_iterations
+        self.parameter_generation = parameter_generation
+
+        # Current x & y position.
+        self.curr_x_position = self.x_position_min
+        self.curr_y_position = self.y_position_min
+
+        # Current FI parameter iteration.
+        self.curr_iteration = 0
+
+    def arm_trigger(self, fault_parameters: dict) -> None:
+        """ Arm the trigger.
+
+        Args:
+            A dict containing the FI parameters.
+        """
+        print(f"Arming DummyLFI trigger with"
+              f"x_position={fault_parameters['x_position']} "
+              f"y_position={fault_parameters['y_position']}, "
+              f"attenuation={fault_parameters['attenuation']}, "
+              f"pulse_width={fault_parameters['pulse_width']}, and "
+              f"trigger_delay={fault_parameters['trigger_delay']}")
+
+    def generate_fi_parameters(self) -> dict:
+        """ Generate LFI parameters within the provided limits.
+
+        Returns:
+            A dict containing the FI parameters.
+        """
+        parameters = {}
+        if self.parameter_generation == "random":
+            parameters["x_position"] = random_float_range(self.x_position_min,
+                                                          self.x_position_max,
+                                                          self.x_position_step)
+            parameters["y_position"] = random_float_range(self.y_position_min,
+                                                          self.y_position_max,
+                                                          self.y_position_step)
+        elif self.parameter_generation == "deterministic":
+            if self.curr_iteration == self.num_iterations:
+                self.curr_iteration = 0
+                if self.curr_y_position < self.y_position_max:
+                    self.curr_y_position += self.y_position_step
+                else:
+                    self.curr_y_position = self.y_position_min
+                    self.curr_x_position += self.x_position_step
+
+            parameters["x_position"] = self.curr_x_position
+            parameters["y_position"] = self.curr_y_position
+            self.curr_iteration += 1
+        else:
+            raise Exception("DummyLFI only supports random/deterministic parameter generation")
+
+        parameters["attenuation"] = random_float_range(self.attenuation_min,
+                                                       self.attenuation_max,
+                                                       self.attenuation_step)
+        parameters["pulse_width"] = random_float_range(self.pulse_width_min,
+                                                       self.pulse_width_max,
+                                                       self.pulse_width_step)
+        parameters["trigger_delay"] = random_float_range(self.trigger_delay_min,
+                                                         self.trigger_delay_max,
+                                                         self.trigger_step)
+        return parameters
+
+    def reset(self) -> None:
+        """ No reset is required for dummy LFI gear.
+        """
+        pass
+
+    def get_num_fault_injections(self) -> int:
+        """ Get number of fault injections.
+
+        Returns: The total number of fault injections performed with DummyEMFI.
+        """
+        if self.parameter_generation == "random":
+            return self.num_iterations
+        elif self.parameter_generation == "deterministic":
+            return ((self.x_position_max - self.x_position_min + 1) /
+                    self.x_position_step) * ((self.y_position_max - self.y_position_min + 1) /
+                                             self.y_position_step) * (self.num_iterations)
+        else:
+            raise Exception("DummyEMFI only supports random/deterministic parameter generation")

--- a/fault_injection/fi_gear/dummy/dummy_vcc.py
+++ b/fault_injection/fi_gear/dummy/dummy_vcc.py
@@ -34,7 +34,10 @@ class DummyVCC:
         Args:
             A dict containing the FI parameters.
         """
-        print(f"Arming DummyVCC trigger with glitch_voltage={fault_parameters['glitch_voltage']} glitch_width={fault_parameters['glitch_width']}, and trigger_delay={fault_parameters['trigger_delay']}")  # noqa: E501
+        print(f"Arming DummyVCC trigger with"
+              f"glitch_voltage={fault_parameters['glitch_voltage']}, "
+              f"glitch_width={fault_parameters['glitch_width']}, and "
+              f"trigger_delay={fault_parameters['trigger_delay']}")
 
     def generate_fi_parameters(self) -> dict:
         """ Generate random voltage glitch parameters within the provided

--- a/fault_injection/fi_gear/fi_gear.py
+++ b/fault_injection/fi_gear/fi_gear.py
@@ -3,6 +3,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+from fi_gear.dummy.dummy_clk import DummyCLK
+from fi_gear.dummy.dummy_emfi import DummyEMFI
+from fi_gear.dummy.dummy_lfi import DummyLFI
 from fi_gear.dummy.dummy_vcc import DummyVCC
 from fi_gear.husky.husky_vcc import HuskyVCC
 
@@ -25,6 +28,54 @@ class FIGear:
                 glitch_width_min = cfg["fisetup"]["glitch_width_min"],
                 glitch_width_max = cfg["fisetup"]["glitch_width_max"],
                 glitch_width_step = cfg["fisetup"]["glitch_width_step"],
+                trigger_delay_min = cfg["fisetup"]["trigger_delay_min"],
+                trigger_delay_max = cfg["fisetup"]["trigger_delay_max"],
+                trigger_step = cfg["fisetup"]["trigger_step"],
+                num_iterations = cfg["fisetup"]["num_iterations"],
+                parameter_generation = cfg["fisetup"]["parameter_generation"])
+        elif self.gear_type == "dummy" and self.fi_type == "clock_glitch":
+            self.gear = DummyCLK(
+                glitch_width_min = cfg["fisetup"]["glitch_width_min"],
+                glitch_width_max = cfg["fisetup"]["glitch_width_max"],
+                glitch_width_step = cfg["fisetup"]["glitch_width_step"],
+                trigger_delay_min = cfg["fisetup"]["trigger_delay_min"],
+                trigger_delay_max = cfg["fisetup"]["trigger_delay_max"],
+                trigger_step = cfg["fisetup"]["trigger_step"],
+                num_iterations = cfg["fisetup"]["num_iterations"],
+                parameter_generation = cfg["fisetup"]["parameter_generation"])
+        elif self.gear_type == "dummy" and self.fi_type == "lfi":
+            self.gear = DummyLFI(
+                x_position_min = cfg["fisetup"]["x_position_min"],
+                x_position_max = cfg["fisetup"]["x_position_max"],
+                x_position_step = cfg["fisetup"]["x_position_step"],
+                y_position_min = cfg["fisetup"]["y_position_min"],
+                y_position_max = cfg["fisetup"]["y_position_max"],
+                y_position_step = cfg["fisetup"]["y_position_step"],
+                attenuation_min = cfg["fisetup"]["attenuation_min"],
+                attenuation_max = cfg["fisetup"]["attenuation_max"],
+                attenuation_step = cfg["fisetup"]["attenuation_step"],
+                pulse_width_min = cfg["fisetup"]["pulse_width_min"],
+                pulse_width_max = cfg["fisetup"]["pulse_width_max"],
+                pulse_width_step = cfg["fisetup"]["pulse_width_step"],
+                trigger_delay_min = cfg["fisetup"]["trigger_delay_min"],
+                trigger_delay_max = cfg["fisetup"]["trigger_delay_max"],
+                trigger_step = cfg["fisetup"]["trigger_step"],
+                num_iterations = cfg["fisetup"]["num_iterations"],
+                parameter_generation = cfg["fisetup"]["parameter_generation"])
+        elif self.gear_type == "dummy" and self.fi_type == "emfi":
+            self.gear = DummyEMFI(
+                x_position_min = cfg["fisetup"]["x_position_min"],
+                x_position_max = cfg["fisetup"]["x_position_max"],
+                x_position_step = cfg["fisetup"]["x_position_step"],
+                y_position_min = cfg["fisetup"]["y_position_min"],
+                y_position_max = cfg["fisetup"]["y_position_max"],
+                y_position_step = cfg["fisetup"]["y_position_step"],
+                voltage_min = cfg["fisetup"]["voltage_min"],
+                voltage_max = cfg["fisetup"]["voltage_max"],
+                voltage_step = cfg["fisetup"]["voltage_step"],
+                pulse_width_min = cfg["fisetup"]["pulse_width_min"],
+                pulse_width_max = cfg["fisetup"]["pulse_width_max"],
+                pulse_width_step = cfg["fisetup"]["pulse_width_step"],
                 trigger_delay_min = cfg["fisetup"]["trigger_delay_min"],
                 trigger_delay_max = cfg["fisetup"]["trigger_delay_max"],
                 trigger_step = cfg["fisetup"]["trigger_step"],


### PR DESCRIPTION
This PR adds dummy drivers for EMFI, LFI, and CLK glitching FI gear that can be used by others as a template for new FI gear.

Closes #250
Closes #251
Closes #252 
