### PR TITLE
[fi] Add Ibex FI characterization handlers

### DIFF
--- a/fault_injection/configs/pen.global_fi.ibex.char.mem_op_loop.yaml
+++ b/fault_injection/configs/pen.global_fi.ibex.char.mem_op_loop.yaml
@@ -1,0 +1,38 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/fi_ibex_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM1"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 10000
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 100
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "ibex_char_mem_op_loop"
+  expected_result: '{"loop_counter1":10000,"loop_counter2":0,"err_status":0}'

--- a/fault_injection/configs/pen.global_fi.ibex.char.reg_op_loop.yaml
+++ b/fault_injection/configs/pen.global_fi.ibex.char.reg_op_loop.yaml
@@ -1,0 +1,38 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/fi_ibex_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM1"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 10000
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 100
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "ibex_char_reg_op_loop"
+  expected_result: '{"loop_counter1":10000,"loop_counter2":0,"err_status":0}'

--- a/fault_injection/configs/pen.global_fi.ibex.char.unrolled_mem_op_loop.yaml
+++ b/fault_injection/configs/pen.global_fi.ibex.char.unrolled_mem_op_loop.yaml
@@ -1,0 +1,38 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/fi_ibex_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM1"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 10000
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 100
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "ibex_char_unrolled_mem_op_loop"
+  expected_result: '{"loop_counter":10000,"err_status":0}'

--- a/objs/fi_ibex_fpga_cw310.bin
+++ b/objs/fi_ibex_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76366b275e69e8f583900ad46caefc910b5655d7ea74b96649aa5db72ac57065
-size 69024
+oid sha256:d42b2a134fb1aecb6f5c55e888143822e19bebb0ff3aca3bd25fe5a52c09316c
+size 188368

--- a/target/communication/fi_ibex_commands.py
+++ b/target/communication/fi_ibex_commands.py
@@ -51,6 +51,33 @@ class OTFIIbex:
         time.sleep(0.01)
         self.uart.write(json.dumps("CharUnrolledRegOpLoop").encode("ascii"))
 
+    def ibex_char_unrolled_mem_op_loop(self) -> None:
+        """ Starts the ibex.char.unrolled_mem_op_loop test.
+        """
+        # IbexFi command.
+        self._ujson_ibex_fi_cmd()
+        # CharUnrolledMemOpLoop command.
+        time.sleep(0.01)
+        self.uart.write(json.dumps("CharUnrolledMemOpLoop").encode("ascii"))
+
+    def ibex_char_reg_op_loop(self) -> None:
+        """ Starts the ibex.char.reg_op_loop test.
+        """
+        # IbexFi command.
+        self._ujson_ibex_fi_cmd()
+        # CharRegOpLoop command.
+        time.sleep(0.01)
+        self.uart.write(json.dumps("CharRegOpLoop").encode("ascii"))
+
+    def ibex_char_mem_op_loop(self) -> None:
+        """ Starts the ibex.char.mem_op_loop test.
+        """
+        # IbexFi command.
+        self._ujson_ibex_fi_cmd()
+        # CharMemOpLoop command.
+        time.sleep(0.01)
+        self.uart.write(json.dumps("CharMemOpLoop").encode("ascii"))
+
     def init_trigger(self) -> None:
         """ Initialize the FI trigger on the chip.
 


### PR DESCRIPTION
Adds command handlers for the following tests used to characterize Ibex:
- ibex.char.mem_op_loop
- ibex.char.reg_op_loop
- ibex.char.unrolled_mem_op_loop

Device code is located in [#20649](https://github.com/lowRISC/opentitan/pull/20649).