### PR TITLE
Fix relative imports

### DIFF
--- a/capture/capture_aes.py
+++ b/capture/capture_aes.py
@@ -23,12 +23,11 @@ from scopes.cycle_converter import convert_num_cycles, convert_offset_cycles
 from scopes.scope import Scope, ScopeConfig, determine_sampling_rate
 from tqdm import tqdm
 
-sys.path.append("../")
-import util.helpers as helpers  # noqa: E402
-from target.cw_fpga import CWFPGA  # noqa: E402
-from util import check_version  # noqa: E402
-from util import plot  # noqa: E402
-from util import data_generator as dg  # noqa: E402
+import util.helpers as helpers
+from target.cw_fpga import CWFPGA
+from util import check_version
+from util import data_generator as dg
+from util import plot
 
 """AES SCA capture script.
 

--- a/capture/capture_kmac.py
+++ b/capture/capture_kmac.py
@@ -27,12 +27,11 @@ from scopes.cycle_converter import convert_num_cycles, convert_offset_cycles
 from scopes.scope import Scope, ScopeConfig, determine_sampling_rate
 from tqdm import tqdm
 
-sys.path.append("../")
-import util.helpers as helpers  # noqa: E402
-from target.cw_fpga import CWFPGA  # noqa: E402
-from util import check_version  # noqa: E402
-from util import plot  # noqa: E402
-from util import data_generator as dg  # noqa: E402
+import util.helpers as helpers
+from target.cw_fpga import CWFPGA
+from util import check_version
+from util import data_generator as dg
+from util import plot
 
 """KMAC SCA capture script.
 

--- a/capture/capture_sha3.py
+++ b/capture/capture_sha3.py
@@ -26,12 +26,11 @@ from scopes.cycle_converter import convert_num_cycles, convert_offset_cycles
 from scopes.scope import Scope, ScopeConfig, determine_sampling_rate
 from tqdm import tqdm
 
-sys.path.append("../")
-import util.helpers as helpers  # noqa: E402
-from target.cw_fpga import CWFPGA  # noqa: E402
-from util import check_version  # noqa: E402
-from util import plot  # noqa: E402
-from util import data_generator as dg  # noqa: E402
+import util.helpers as helpers
+from target.cw_fpga import CWFPGA
+from util import check_version
+from util import data_generator as dg
+from util import plot
 
 logger = logging.getLogger()
 

--- a/capture/scopes/chipwhisperer/husky.py
+++ b/capture/scopes/chipwhisperer/husky.py
@@ -9,7 +9,7 @@ import chipwhisperer as cw
 import numpy as np
 from scopes.chipwhisperer.cw_segmented import CwSegmented
 
-sys.path.append("../../../")
+sys.path.append("../")
 from util import check_version  # noqa: E402
 
 

--- a/fault_injection/fi_ibex.py
+++ b/fault_injection/fi_ibex.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -13,12 +12,10 @@ from fi_gear.fi_gear import FIGear
 from project_library.project import FIProject, FISuccess, ProjectConfig
 from tqdm import tqdm
 
-sys.path.append("../")
-import util.helpers as helpers  # noqa: E402
-from target.communication.fi_ibex_commands import OTUART  # noqa: E402
-from target.communication.fi_ibex_commands import OTFIIbex  # noqa: E402
-from target.cw_fpga import CWFPGA  # noqa: E402
-from util import plot  # noqa: E402
+import util.helpers as helpers
+from target.communication.fi_ibex_commands import OTUART, OTFIIbex
+from target.cw_fpga import CWFPGA
+from util import plot
 
 logger = logging.getLogger()
 

--- a/fault_injection/project_library/project.py
+++ b/fault_injection/project_library/project.py
@@ -3,14 +3,12 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
 from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
 from typing import Optional
 
-sys.path.append("../")
-from fault_injection.project_library.ot_fi_library.fi_library import (  # noqa: E402
+from fault_injection.project_library.ot_fi_library.fi_library import (
     FILibrary, FIResult)
 
 


### PR DESCRIPTION
This PR removes the path manipulations in the capture and FI scripts. However, due to our directory structure, in some scripts `sys.path.append("../../")` is still needed to find the imports.
Closes #255.