### PR TITLE
[db] Store binary blob into database

### DIFF
--- a/capture/capture_aes.py
+++ b/capture/capture_aes.py
@@ -431,11 +431,21 @@ def main(argv=None):
     metadata["offset_samples"] = scope.scope_cfg.offset_samples
     metadata["scope_gain"] = scope.scope_cfg.scope_gain
     metadata["cfg_file"] = str(args.cfg)
-    metadata["fpga_bitstream"] = cfg["target"]["fpga_bitstream"]
-    # TODO: Store binary into database instead of binary path.
-    # (Issue lowrisc/ot-sca#214)
-    metadata["fw_bin"] = cfg["target"]["fw_bin"]
+    # Store bitstream information.
+    metadata["fpga_bitstream_path"] = cfg["target"]["fpga_bitstream"]
+    metadata["fpga_bitstream_crc"] = helpers.file_crc(cfg["target"]["fpga_bitstream"])
+    if args.save_bitstream:
+        metadata["fpga_bitstream"] = helpers.get_binary_blob(cfg["target"]["fpga_bitstream"])
+    # Store binary information.
+    metadata["fw_bin_path"] = cfg["target"]["fw_bin"]
+    metadata["fw_bin_crc"] = helpers.file_crc(cfg["target"]["fw_bin"])
+    if args.save_binary:
+        metadata["fw_bin"] = helpers.get_binary_blob(cfg["target"]["fw_bin"])
+    # Store user provided notes.
     metadata["notes"] = args.notes
+    # Store the Git hash.
+    metadata["git_hash"] = helpers.get_git_hash()
+    # Write metadata into project database.
     project.write_metadata(metadata)
 
     # Save and close project.

--- a/capture/capture_kmac.py
+++ b/capture/capture_kmac.py
@@ -465,11 +465,21 @@ def main(argv=None):
     metadata["offset_samples"] = scope.scope_cfg.offset_samples
     metadata["scope_gain"] = scope.scope_cfg.scope_gain
     metadata["cfg_file"] = str(args.cfg)
-    metadata["fpga_bitstream"] = cfg["target"]["fpga_bitstream"]
-    # TODO: Store binary into database instead of binary path.
-    # (Issue lowrisc/ot-sca#214)
-    metadata["fw_bin"] = cfg["target"]["fw_bin"]
+    # Store bitstream information.
+    metadata["fpga_bitstream_path"] = cfg["target"]["fpga_bitstream"]
+    metadata["fpga_bitstream_crc"] = helpers.file_crc(cfg["target"]["fpga_bitstream"])
+    if args.save_bitstream:
+        metadata["fpga_bitstream"] = helpers.get_binary_blob(cfg["target"]["fpga_bitstream"])
+    # Store binary information.
+    metadata["fw_bin_path"] = cfg["target"]["fw_bin"]
+    metadata["fw_bin_crc"] = helpers.file_crc(cfg["target"]["fw_bin"])
+    if args.save_binary:
+        metadata["fw_bin"] = helpers.get_binary_blob(cfg["target"]["fw_bin"])
+    # Store user provided notes.
     metadata["notes"] = args.notes
+    # Store the Git hash.
+    metadata["git_hash"] = helpers.get_git_hash()
+    # Write metadata into project database.
     project.write_metadata(metadata)
 
     # Save and close project.

--- a/capture/capture_sha3.py
+++ b/capture/capture_sha3.py
@@ -435,11 +435,21 @@ def main(argv=None):
     metadata["offset_samples"] = scope.scope_cfg.offset_samples
     metadata["scope_gain"] = scope.scope_cfg.scope_gain
     metadata["cfg_file"] = str(args.cfg)
-    metadata["fpga_bitstream"] = cfg["target"]["fpga_bitstream"]
-    # TODO: Store binary into database instead of binary path.
-    # (Issue lowrisc/ot-sca#214)
-    metadata["fw_bin"] = cfg["target"]["fw_bin"]
+    # Store bitstream information.
+    metadata["fpga_bitstream_path"] = cfg["target"]["fpga_bitstream"]
+    metadata["fpga_bitstream_crc"] = helpers.file_crc(cfg["target"]["fpga_bitstream"])
+    if args.save_bitstream:
+        metadata["fpga_bitstream"] = helpers.get_binary_blob(cfg["target"]["fpga_bitstream"])
+    # Store binary information.
+    metadata["fw_bin_path"] = cfg["target"]["fw_bin"]
+    metadata["fw_bin_crc"] = helpers.file_crc(cfg["target"]["fw_bin"])
+    if args.save_binary:
+        metadata["fw_bin"] = helpers.get_binary_blob(cfg["target"]["fw_bin"])
+    # Store user provided notes.
     metadata["notes"] = args.notes
+    # Store the Git hash.
+    metadata["git_hash"] = helpers.get_git_hash()
+    # Write metadata into project database.
     project.write_metadata(metadata)
 
     # Save and close project.

--- a/fault_injection/fi_ibex.py
+++ b/fault_injection/fi_ibex.py
@@ -178,12 +178,21 @@ def main(argv=None):
     # Save metadata.
     metadata = {}
     metadata["datetime"] = datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
-    metadata["cfg"] = cfg
-    metadata["fpga_bitstream"] = cfg["target"]["fpga_bitstream"]
-    # TODO: Store binary into database instead of binary path.
-    # (Issue lowrisc/ot-sca#214)
-    metadata["fw_bin"] = cfg["target"]["fw_bin"]
+    # Store bitstream information.
+    metadata["fpga_bitstream_path"] = cfg["target"]["fpga_bitstream"]
+    metadata["fpga_bitstream_crc"] = helpers.file_crc(cfg["target"]["fpga_bitstream"])
+    if args.save_bitstream:
+        metadata["fpga_bitstream"] = helpers.get_binary_blob(cfg["target"]["fpga_bitstream"])
+    # Store binary information.
+    metadata["fw_bin_path"] = cfg["target"]["fw_bin"]
+    metadata["fw_bin_crc"] = helpers.file_crc(cfg["target"]["fw_bin"])
+    if args.save_binary:
+        metadata["fw_bin"] = helpers.get_binary_blob(cfg["target"]["fw_bin"])
+    # Store user provided notes.
     metadata["notes"] = args.notes
+    # Store the Git hash.
+    metadata["git_hash"] = helpers.get_git_hash()
+    # Write metadata into project database.
     project.write_metadata(metadata)
 
     # Save and close project.

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -6,6 +6,7 @@
 bokeh==2.4.3
 cffi==1.16.0
 codetiming==1.4.0
+gitpython==3.1.40
 libusb1==3.1.0
 matplotlib==3.8.1
 more-itertools==10.1.0

--- a/util/helpers.py
+++ b/util/helpers.py
@@ -3,7 +3,52 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import zlib
 from pathlib import Path
+
+import git
+
+
+def get_git_hash() -> str:
+    """Get the Git hash of the repository
+
+    Returns:
+        String containing the Git hash.
+    """
+    repo = git.Repo(search_parent_directories=True)
+    return repo.head.object.hexsha
+
+
+def file_crc(file_path: Path) -> int:
+    """Calculates CRC32 of the provided file
+
+    Args:
+        file_path: The path of the file to calculate the CRC32.
+
+    Returns:
+        Int containing the CRC32 of the file.
+    """
+    crc_str = 0
+    with open(file_path, "rb") as f:
+        # Read 1MiB of the binary & calculate CRC32.
+        while chunk := f.read(1024 * 1024):
+            crc_str = zlib.crc32(chunk, crc_str)
+    return crc_str
+
+
+def get_binary_blob(file_path: Path) -> bytearray:
+    """Read binary blob from the provided file
+
+    Args:
+        file_path: The path of the file,
+
+    Returns:
+        Bytearray containing the bytes of the file.
+    """
+    binary_blob = ""
+    with open(file_path, "rb") as f:
+        binary_blob = f.read()
+    return bytearray(binary_blob)
 
 
 def ap_check_file_exists(file_path: str) -> Path:
@@ -59,13 +104,24 @@ def parse_arguments(argv):
                         type=ap_check_dir_exists,
                         required=True,
                         help="Path of the output project directory")
-
     parser.add_argument("-n",
                         "--note",
                         dest="notes",
                         type=str,
                         required=False,
                         help="Notes to be stored in the project database")
+    parser.add_argument("-b",
+                        "--save_bitstream",
+                        dest="save_bitstream",
+                        type=bool,
+                        required=False,
+                        help="Save bitstream into project database")
+    parser.add_argument("-f",
+                        "--save_binary",
+                        dest="save_binary",
+                        type=bool,
+                        required=False,
+                        help="Save binary into project database")
 
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
This PR enables the user to save the bitstream and the used binary into the project database. Moreover, a CRC of the used binary and bistream is calculated and stored into the database.

Closes #214.