### PR TITLE
[tvla] Fix plotting issues with new database and metadata format

### DIFF
--- a/analysis/configs/tvla_cfg_aes_specific_byte0_rnd0.yaml
+++ b/analysis/configs/tvla_cfg_aes_specific_byte0_rnd0.yaml
@@ -1,4 +1,4 @@
-project_file: projects/simple_capture_aes_sca
+project_file: ../capture/projects/simple_capture_aes_sca
 trace_file: null
 trace_start: null
 trace_end: null

--- a/analysis/configs/tvla_cfg_kmac.yaml
+++ b/analysis/configs/tvla_cfg_kmac.yaml
@@ -1,4 +1,4 @@
-project_file: projects/opentitan_simple_kmac.cwp
+project_file: ../capture/projects/simple_capture_kmac_sca
 trace_file: null
 trace_start: null
 trace_end: null
@@ -14,3 +14,6 @@ ttest_step_file: null
 plot_figures: true
 general_test: true
 mode: kmac
+filter_traces: true
+trace_threshold: 1000
+trace_db: ot_trace_library

--- a/analysis/configs/tvla_cfg_otbn_keygen.yaml
+++ b/analysis/configs/tvla_cfg_otbn_keygen.yaml
@@ -1,4 +1,4 @@
-project_file: projects/opentitan_otbn_vertical_keygen.cwp
+project_file: ../capture/projects/otbn_vertical_sca_cw310_keygen
 trace_file: null
 trace_start: null
 trace_end: null
@@ -16,4 +16,7 @@ general_test: true
 mode: otbn
 key_len_bytes: 40
 sample_start: null
-num_samples : 3500
+num_samples : null
+filter_traces: true
+trace_threshold: 1000
+trace_db: ot_trace_library

--- a/analysis/configs/tvla_cfg_otbn_modinv.yaml
+++ b/analysis/configs/tvla_cfg_otbn_modinv.yaml
@@ -1,4 +1,4 @@
-project_file: projects/opentitan_otbn_vertical_modinv.cwp
+project_file: ../capture/projects/otbn_vertical_sca_cw310_modinv
 trace_file: null
 trace_start: null
 trace_end: null
@@ -16,4 +16,7 @@ general_test: true
 mode: otbn
 key_len_bytes: 32
 sample_start: null
-num_samples : 10000
+num_samples : null
+filter_traces: true
+trace_threshold: 1000
+trace_db: ot_trace_library

--- a/analysis/configs/tvla_cfg_sha3.yaml
+++ b/analysis/configs/tvla_cfg_sha3.yaml
@@ -1,4 +1,4 @@
-project_file: projects/opentitan_simple_sha3.cwp
+project_file: ../capture/projects/simple_capture_sha3_sca
 trace_file: null
 trace_start: null
 trace_end: null
@@ -14,3 +14,6 @@ ttest_step_file: null
 plot_figures: true
 general_test: true
 mode: sha3
+filter_traces: true
+trace_threshold: 1000
+trace_db: ot_trace_library

--- a/capture/capture_aes.py
+++ b/capture/capture_aes.py
@@ -429,6 +429,8 @@ def main(argv=None):
     metadata["cfg"] = cfg
     metadata["num_samples"] = scope.scope_cfg.num_samples
     metadata["offset_samples"] = scope.scope_cfg.offset_samples
+    metadata["sampling_rate"] = scope.scope_cfg.sampling_rate
+    metadata["num_traces"] = capture_cfg.num_traces
     metadata["scope_gain"] = scope.scope_cfg.scope_gain
     metadata["cfg_file"] = str(args.cfg)
     # Store bitstream information.

--- a/capture/capture_kmac.py
+++ b/capture/capture_kmac.py
@@ -463,6 +463,8 @@ def main(argv=None):
     metadata["cfg"] = cfg
     metadata["num_samples"] = scope.scope_cfg.num_samples
     metadata["offset_samples"] = scope.scope_cfg.offset_samples
+    metadata["sampling_rate"] = scope.scope_cfg.sampling_rate
+    metadata["num_traces"] = capture_cfg.num_traces
     metadata["scope_gain"] = scope.scope_cfg.scope_gain
     metadata["cfg_file"] = str(args.cfg)
     # Store bitstream information.

--- a/capture/capture_otbn.py
+++ b/capture/capture_otbn.py
@@ -746,7 +746,8 @@ def main(argv=None):
     metadata["offset_samples"] = scope.scope_cfg.offset_samples
     metadata["scope_gain"] = scope.scope_cfg.scope_gain
     if cfg["capture"]["scope_select"] == "husky":
-        metadata["sampling_rate"] = scope.scope.scope.clock.adc_freq / scope.scope.scope.adc.decimate
+        metadata[
+            "sampling_rate"] = scope.scope.scope.clock.adc_freq / scope.scope.scope.adc.decimate
         metadata["samples_trigger_high"] = scope.scope.scope.adc.trig_count
     else:
         metadata["sampling_rate"] = scope.scope_cfg.sampling_rate

--- a/capture/capture_otbn.py
+++ b/capture/capture_otbn.py
@@ -745,6 +745,12 @@ def main(argv=None):
     metadata["num_samples"] = scope.scope_cfg.num_samples
     metadata["offset_samples"] = scope.scope_cfg.offset_samples
     metadata["scope_gain"] = scope.scope_cfg.scope_gain
+    if cfg["capture"]["scope_select"] == "husky":
+        metadata["sampling_rate"] = scope.scope.scope.clock.adc_freq / scope.scope.scope.adc.decimate
+        metadata["samples_trigger_high"] = scope.scope.scope.adc.trig_count
+    else:
+        metadata["sampling_rate"] = scope.scope_cfg.sampling_rate
+    metadata["num_traces"] = capture_cfg.num_traces
     metadata["cfg_file"] = str(args.cfg)
     # Store bitstream information.
     metadata["fpga_bitstream_path"] = cfg["target"]["fpga_bitstream"]

--- a/capture/capture_sha3.py
+++ b/capture/capture_sha3.py
@@ -433,6 +433,8 @@ def main(argv=None):
     metadata["cfg"] = cfg
     metadata["num_samples"] = scope.scope_cfg.num_samples
     metadata["offset_samples"] = scope.scope_cfg.offset_samples
+    metadata["sampling_rate"] = scope.scope_cfg.sampling_rate
+    metadata["num_traces"] = capture_cfg.num_traces
     metadata["scope_gain"] = scope.scope_cfg.scope_gain
     metadata["cfg_file"] = str(args.cfg)
     # Store bitstream information.

--- a/capture/configs/otbn_vertical_keygen_sca_cw310.yaml
+++ b/capture/configs/otbn_vertical_keygen_sca_cw310.yaml
@@ -28,8 +28,6 @@ capture:
   scope_select: husky
   show_plot: True
   plot_traces: 100
-  num_cycles: 200
-  offset_cycles: 0
   num_traces: 1000
   trace_threshold: 10000
   trace_db: ot_trace_library

--- a/capture/configs/otbn_vertical_modinv_sca_cw310.yaml
+++ b/capture/configs/otbn_vertical_modinv_sca_cw310.yaml
@@ -14,7 +14,7 @@ target:
 husky:
   sampling_rate: 200000000
   num_segments: 20
-  num_cycles: 200
+  num_cycles: 1000
   offset_cycles: 0
   scope_gain: 24
   adc_mul: 1
@@ -28,8 +28,6 @@ capture:
   scope_select: husky
   show_plot: True
   plot_traces: 100
-  num_cycles: 100000
-  offset_cycles: 0
   num_traces: 1000
   trace_threshold: 10000
   trace_db: ot_trace_library


### PR DESCRIPTION
This commit fixes incompatibility of tvla plotting with the new database and metadata format.

For this, additional metadata is stored in aes, otbn, kmac and sha3 capture. Also, a new wrapper function for plotting is added to the tvla script. Finally, aes, otbn, kmac and sha3 config files are adjusted.

Further, this PR adds code to also include metadata in plots of aes specific tests.

Through this PR two tasks in https://github.com/lowRISC/ot-sca/issues/72 are addressed:
- [x] At the moment, TVLA figures contain meta-data only for general TVLA test. We should enable the same for AES specific TVLA tests.
- [x] At the moment, tvla.py cannot generate some figures if data is loaded from the new database format.