### PR TITLE
[capture] Re-enable all CW trace storage segments before saving to disk

### DIFF
--- a/capture/capture_aes.py
+++ b/capture/capture_aes.py
@@ -450,6 +450,8 @@ def main(argv=None):
     # Write metadata into project database.
     project.write_metadata(metadata)
 
+    # Finale the capture.
+    project.finalize_capture(capture_cfg.num_traces)
     # Save and close project.
     project.save()
 

--- a/capture/capture_kmac.py
+++ b/capture/capture_kmac.py
@@ -484,6 +484,8 @@ def main(argv=None):
     # Write metadata into project database.
     project.write_metadata(metadata)
 
+    # Finale the capture.
+    project.finalize_capture(capture_cfg.num_traces)
     # Save and close project.
     project.save()
 

--- a/capture/capture_otbn.py
+++ b/capture/capture_otbn.py
@@ -770,6 +770,8 @@ def main(argv=None):
     # Write metadata into project database.
     project.write_metadata(metadata)
 
+    # Finale the capture.
+    project.finalize_capture(capture_cfg.num_traces)
     # Save and close project.
     project.save()
 

--- a/capture/capture_sha3.py
+++ b/capture/capture_sha3.py
@@ -454,6 +454,8 @@ def main(argv=None):
     # Write metadata into project database.
     project.write_metadata(metadata)
 
+    # Finale the capture.
+    project.finalize_capture(capture_cfg.num_traces)
     # Save and close project.
     project.save()
 

--- a/capture/project_library/project.py
+++ b/capture/project_library/project.py
@@ -159,8 +159,21 @@ class SCAProject:
             # See:
             # - _updateRanges() in chipwhisperer/common/api/TraceManager.py.
             # - https://github.com/newaetech/chipwhisperer/issues/344
+            #
+            # Before saving the CW project to disk, all trace storage segments need to be
+            # re-enabled using finalize_capture().
             if num_segments_storage != len(self.project.segments):
                 if num_segments_storage >= 2:
                     self.project.traces.tm.setTraceSegmentStatus(num_segments_storage - 2, False)
                 num_segments_storage = len(self.project.segments)
             return num_segments_storage
+
+    def finalize_capture(self, num_traces):
+        """Before saving the CW project to disk, re-enable all trace storage segments."""
+        # The function optimize_capture above disables all but the most recent two trace storage
+        # segments to maintain the capture rate. Before saving the CW project to disk, this
+        # needs to be undone.
+        if self.project_cfg.type == "cw":
+            for s in range(len(self.project.segments)):
+                self.project.traces.tm.setTraceSegmentStatus(s, True)
+            assert len(self.project.traces) == num_traces


### PR DESCRIPTION
When using the CW trace database format, we disable all but the last two trace storage segments during captures to maintain high capture rates. Before storing the database to disk at the end of the capture, all trace storage segments need to be re-enabled. Otherwise, only 20k traces are read from the database upon loading.

This resolves lowRISC/ot-sca#274.