### PR TITLE
[tvla] Fix plotting of results for byte-specific AES, as well as when using the legacy CW database format

### DIFF
--- a/analysis/tvla.py
+++ b/analysis/tvla.py
@@ -170,7 +170,11 @@ def tvla_plotting_fnc(axs, num_orders, i_rnd, i_byte, ttest_trace,
     """
     c = np.ones(num_samples)
     xaxs = range(sample_start, sample_start + num_samples)
-    offset = int(metadata["offset_samples"])
+    # Catch case where offset data isn't saved to project file (e.g. older measurement)
+    try:
+        offset = int(metadata["offset_samples"])
+    except KeyError:
+        offset = 0
     # Catch case where trigger data isn't saved to project file (e.g. older measurement)
     try:
         trigger_samples = int(metadata["samples_trigger_high"])
@@ -809,17 +813,16 @@ def run_tvla(ctx: typer.Context):
                                             threshold, num_samples,
                                             sample_start, metadata)
 
+                    title = "TVLA of " + "aes_t_test_round_" + str(
+                        rnd_list[i_rnd]) + "_byte_" + str(byte_list[i_byte])
                     # Catch case where datetime data isn't saved
                     # to project file (e.g. older measurement)
                     try:
-                        axs[0].set_title("TVLA of " + "aes_t_test_round_" +
-                                         str(rnd_list[i_rnd]) + "_byte_" +
-                                         str(byte_list[i_byte]) + "\n" +
-                                         "Captured: " + metadata['datetime'])
+                        title = title + "\n" + "Captured: " + metadata[
+                            'datetime']
                     except KeyError:
-                        axs[0].set_title("TVLA of " + "aes_t_test_round_" +
-                                         str(rnd_list[i_rnd])
-                                         ) + "_byte_" + str(byte_list[i_byte])
+                        title = title
+                    axs[0].set_title(title)
 
                     # Add metadata to plot
                     if textbox != "":
@@ -853,14 +856,13 @@ def run_tvla(ctx: typer.Context):
                                     single_trace, threshold, num_samples,
                                     sample_start, metadata)
 
+            title = "TVLA of " + (cfg["project_file"]).rsplit('/')[3]
             # Catch case where datetime data isn't saved to project file (e.g. older measurement)
             try:
-                axs[0].set_title("TVLA of " +
-                                 (cfg["project_file"]).rsplit('/')[3] + "\n" +
-                                 "Captured: " + metadata["datetime"])
+                title = title + "\n" + "Captured: " + metadata['datetime']
             except KeyError:
-                axs[0].set_title("TVLA of " +
-                                 (cfg["project_file"]).rsplit('/')[3])
+                title = title
+            axs[0].set_title(title)
 
             # Add metadata to plot
             if textbox != "":

--- a/analysis/tvla.py
+++ b/analysis/tvla.py
@@ -163,8 +163,9 @@ def compute_histograms_aes(trace_resolution, rnd_list, byte_list, traces, leakag
     return histograms
 
 
-def tvla_plotting_fnc(axs, num_orders, ttest_trace, single_trace, threshold,
-                      num_samples, sample_start, metadata):
+def tvla_plotting_fnc(axs, num_orders, i_rnd, i_byte, ttest_trace,
+                      single_trace, threshold, num_samples, sample_start,
+                      metadata):
     """Plotting trace in different colors, depending on where the trigger is high
     """
     c = np.ones(num_samples)
@@ -205,17 +206,18 @@ def tvla_plotting_fnc(axs, num_orders, ttest_trace, single_trace, threshold,
         axs[1 + i_order].plot(xaxs, c * threshold, "r")
         axs[1 + i_order].plot(xaxs, -threshold * c, "r")
         if trigger_high > 0:
-            axs[1 + i_order].plot(xaxs[:trigger_high],
-                                  ttest_trace[i_order, 0,
-                                              0][:trigger_high], "grey")
+            axs[1 + i_order].plot(
+                xaxs[:trigger_high],
+                ttest_trace[i_order, i_rnd, i_byte][:trigger_high], "grey")
         if trigger_low > trigger_high:
             axs[1 + i_order].plot(
                 xaxs[trigger_high:trigger_low],
-                ttest_trace[i_order, 0, 0][trigger_high:trigger_low], "k")
+                ttest_trace[i_order, i_rnd,
+                            i_byte][trigger_high:trigger_low], "k")
         if trigger_low < num_samples:
-            axs[1 + i_order].plot(xaxs[trigger_low:],
-                                  ttest_trace[i_order, 0,
-                                              0][trigger_low:], "grey")
+            axs[1 + i_order].plot(
+                xaxs[trigger_low:], ttest_trace[i_order, i_rnd,
+                                                i_byte][trigger_low:], "grey")
 
     return axs
 
@@ -795,16 +797,17 @@ def run_tvla(ctx: typer.Context):
 
         # Plotting figures for t-test statistics vs. time.
         log.info("Plotting T-test Statistics vs. Time.")
-        fig, axs = plt.subplots(num_orders + 1, 1, sharex=True)
+
         if cfg["mode"] == "aes" and general_test is False:
             # By default the figures are saved under tmp/t_test_round_x_byte_y.png.
             for i_rnd in range(num_rnds):
                 for i_byte in range(num_bytes):
 
-                    axs = tvla_plotting_fnc(axs, num_orders, ttest_trace,
-                                            single_trace, threshold,
-                                            num_samples, sample_start,
-                                            metadata)
+                    fig, axs = plt.subplots(num_orders + 1, 1, sharex=True)
+                    axs = tvla_plotting_fnc(axs, num_orders, i_rnd, i_byte,
+                                            ttest_trace, single_trace,
+                                            threshold, num_samples,
+                                            sample_start, metadata)
 
                     # Catch case where datetime data isn't saved
                     # to project file (e.g. older measurement)
@@ -845,9 +848,10 @@ def run_tvla(ctx: typer.Context):
                         plt.close()
 
         else:
-            axs = tvla_plotting_fnc(axs, num_orders, ttest_trace, single_trace,
-                                    threshold, num_samples, sample_start,
-                                    metadata)
+            fig, axs = plt.subplots(num_orders + 1, 1, sharex=True)
+            axs = tvla_plotting_fnc(axs, num_orders, 0, 0, ttest_trace,
+                                    single_trace, threshold, num_samples,
+                                    sample_start, metadata)
 
             # Catch case where datetime data isn't saved to project file (e.g. older measurement)
             try:


### PR DESCRIPTION
For both these cases we should maybe add a CI check.