### PR TITLE
[capture, sha3, kmac] Seed software LFSR also in non-batch mode

### DIFF
--- a/capture/capture_kmac.py
+++ b/capture/capture_kmac.py
@@ -168,14 +168,16 @@ def configure_cipher(cfg, target, capture_cfg) -> OTKMAC:
     ot_prng = OTPRNG(target=target.target, protocol=capture_cfg.protocol,
                      port=ot_uart.uart)
 
-    # If batch mode, configure PRNGs.
+    # Configure PRNGs.
+    # Seed the software LFSR used for initial key masking.
+    ot_kmac.write_lfsr_seed(cfg["test"]["lfsr_seed"].to_bytes(4, "little"))
+
+    # Seed the PRNG used for generating keys and plaintexts in batch mode.
     if capture_cfg.batch_mode:
         # Seed host's PRNG.
         random.seed(cfg["test"]["batch_prng_seed"])
 
-        # Seed the target's PRNGs for initial key masking, and additionally
-        # turn off masking when '0'.
-        ot_kmac.write_lfsr_seed(cfg["test"]["lfsr_seed"].to_bytes(4, "little"))
+        # Seed the target's PRNG.
         ot_prng.seed_prng(cfg["test"]["batch_prng_seed"].to_bytes(4, "little"))
 
     return ot_kmac

--- a/capture/capture_sha3.py
+++ b/capture/capture_sha3.py
@@ -159,12 +159,16 @@ def configure_cipher(cfg, target, capture_cfg) -> OTSHA3:
     else:
         ot_sha3.set_mask_on()
 
-    # If batch mode, configure PRNGs.
+    # Configure PRNGs.
+    # Seed the software LFSR.
+    ot_sha3.write_lfsr_seed(cfg["test"]["lfsr_seed"].to_bytes(4, "little"))
+
+    # Seed the PRNG used for generating plaintexts in batch mode.
     if capture_cfg.batch_mode:
         # Seed host's PRNG.
         random.seed(cfg["test"]["batch_prng_seed"])
 
-        ot_sha3.write_lfsr_seed(cfg["test"]["lfsr_seed"].to_bytes(4, "little"))
+        # Seed the target's PRNG.
         ot_prng.seed_prng(cfg["test"]["batch_prng_seed"].to_bytes(4, "little"))
 
     return ot_sha3


### PR DESCRIPTION
At least for KMAC, the software LFSR is used to mask initial keys in non-batch mode.

This got factored out of #280.