### PR TITLE
[tvla] Enable passing lists of selected rounds/bytes for byte-specific AES, add new CI job

### DIFF
--- a/analysis/configs/tvla_cfg_aes_specific_byte0_rnd0.yaml
+++ b/analysis/configs/tvla_cfg_aes_specific_byte0_rnd0.yaml
@@ -5,8 +5,8 @@ trace_end: null
 leakage_file: null
 save_to_disk: null
 save_to_disk_ttest: null
-round_select: 0
-byte_select: 0
+round_select: [0]
+byte_select: [0]
 input_histogram_file: null
 output_histogram_file: null
 number_of_steps: 1

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -154,6 +154,16 @@ jobs:
   - publish: ./ci/projects/aes_sca_random_cw305.html
     artifact: traces_aes_random_cw305
     displayName: "Upload AES Random traces"
+  - bash: |
+      set -e
+      pushd ci
+      ../analysis/tvla.py --cfg-file cfg/ci_tvla_cfg_aes_specific_byte_0_15_rnd_0_1.yaml run-tvla
+      popd
+    displayName: "Perform specific TVLA on AES Random traces"
+    continueOnError: True
+  - publish: ./ci/tmp/figures
+    artifact: tvla_figures_aes_specific
+    displayName: "Upload figures of specific TVLA for AES."
 - job: kmac_sca_capture_cw310
   displayName: "Capture KMAC SCA traces (CW310)"
   timeoutInMinutes: 30

--- a/ci/cfg/ci_tvla_cfg_aes_specific_byte0_rnd0.yaml
+++ b/ci/cfg/ci_tvla_cfg_aes_specific_byte0_rnd0.yaml
@@ -5,8 +5,8 @@ trace_end: null
 leakage_file: null
 save_to_disk: null
 save_to_disk_ttest: null
-round_select: 0
-byte_select: 0
+round_select: [0]
+byte_select: [0]
 input_histogram_file: null
 output_histogram_file: null
 number_of_steps: 1

--- a/ci/cfg/ci_tvla_cfg_aes_specific_byte_0_15_rnd_0_1.yaml
+++ b/ci/cfg/ci_tvla_cfg_aes_specific_byte_0_15_rnd_0_1.yaml
@@ -1,0 +1,19 @@
+project_file: projects/aes_sca_random_cw305
+trace_file: null
+trace_start: null
+trace_end: null
+leakage_file: null
+save_to_disk: null
+save_to_disk_ttest: true
+round_select: [0, 1]
+byte_select: [0, 15]
+input_histogram_file: null
+output_histogram_file: null
+number_of_steps: 4
+ttest_step_file: null
+plot_figures: true
+general_test: false
+mode: aes
+filter_traces: false
+sample_start: 0
+num_samples: 300


### PR DESCRIPTION
This PR is related to #287 and contains two commits:
1. Enable passing lists of selected rounds and bytes for the byte-specific AES TLVA
2. Add a new CI job to exactly test this as well as other byte-specific TVLA functions