### PR TITLE
[db] Fix DB opening and closing

### DIFF
--- a/capture/project_library/project.py
+++ b/capture/project_library/project.py
@@ -72,7 +72,7 @@ class SCAProject:
         if self.project_cfg.type == "cw":
             self.project.close(save = save)
         elif self.project_cfg.type == "ot_trace_library":
-            self.project.flush_to_disk()
+            self.project.close(save = save)
 
         self.project = None
 


### PR DESCRIPTION
This PR fixes issues that could occur when accessing the DB using multiple processes:
- When opening the DB, check if the DB already exists.
- When closing the DB, properly close the connection to the DB engine.

Moreover, also check if the user accidentally did not provide the DB file path with the .db extension. If this happens, simply add it to the path.