### PR TITLE
[db] Fix bug in array slicing

### DIFF
--- a/analysis/tvla.py
+++ b/analysis/tvla.py
@@ -524,7 +524,7 @@ def run_tvla(ctx: typer.Context):
                     keys = np.empty((num_traces_orig, 16), dtype=np.uint8)
 
                 if general_test is False:
-                    keys[:] = project.get_keys()[trace_start:trace_end + 1]
+                    keys[:] = project.get_keys(trace_start, trace_end + 1)
                 else:
                     # Existing KMAC trace sets use a mix of bytes strings and ChipWhisperer byte
                     # arrays. For compatiblity, we need to convert everything to numpy arrays.

--- a/capture/project_library/ot_trace_library/trace_library.py
+++ b/capture/project_library/ot_trace_library/trace_library.py
@@ -118,10 +118,17 @@ class TraceLibrary:
             The traces from the database.
         """
         self.flush_to_disk()
-        if start and end:
+        if (start is not None) and (end is not None):
+            # SQL ID starts at 1.
+            start = start + 1
             query = db.select(self.traces_table).where(
                 (self.traces_table.c.trace_id >= start) &
                 (self.traces_table.c.trace_id <= end))
+        elif (start is not None):
+            # SQL ID starts at 1.
+            start = start + 1
+            query = db.select(self.traces_table).where(
+                self.traces_table.c.trace_id == start)
         else:
             query = db.select(self.traces_table)
 
@@ -143,8 +150,12 @@ class TraceLibrary:
         Returns:
             The waves from the database in the type wave_datatype.
         """
-        return [np.frombuffer(b, self.wave_datatype)
-                for b in self.get_waves_bytearray(start, end)]
+        waves = [np.frombuffer(b, self.wave_datatype)
+                 for b in self.get_waves_bytearray(start, end)]
+        if len(waves) == 1:
+            return waves[0]
+        else:
+            return waves
 
     def get_plaintexts(self, start: Optional[int] = None,
                        end: Optional[int] = None):
@@ -154,8 +165,12 @@ class TraceLibrary:
         Returns:
             The int plaintexts from the database.
         """
-        return [np.frombuffer(trace.plaintext, np.uint8)
-                for trace in self.get_traces(start, end)]
+        plaintexts = [np.frombuffer(trace.plaintext, np.uint8)
+                      for trace in self.get_traces(start, end)]
+        if len(plaintexts) == 1:
+            return plaintexts[0]
+        else:
+            return plaintexts
 
     def get_keys(self, start: Optional[int] = None,
                  end: Optional[int] = None):
@@ -165,8 +180,12 @@ class TraceLibrary:
         Returns:
             The int keys from the database.
         """
-        return [np.frombuffer(trace.key, np.uint8)
-                for trace in self.get_traces(start, end)]
+        keys = [np.frombuffer(trace.key, np.uint8)
+                for trace in self.get_traces(start, end)][0]
+        if len(keys) == 1:
+            return keys[0]
+        else:
+            return keys
 
     def write_metadata(self, metadata):
         """ Write metadata into database.

--- a/capture/project_library/project.py
+++ b/capture/project_library/project.py
@@ -101,7 +101,12 @@ class SCAProject:
         """ Get waves from project.
         """
         if self.project_cfg.type == "cw":
-            return self.project.waves[start:end]
+            if (start is not None) and (end is not None):
+                return self.project.waves[start:end]
+            elif start is not None:
+                return self.project.waves[start]
+            else:
+                return self.project.waves
         elif self.project_cfg.type == "ot_trace_library":
             return self.project.get_waves(start, end)
 
@@ -109,8 +114,10 @@ class SCAProject:
         """ Get keys[start, end] from project.
         """
         if self.project_cfg.type == "cw":
-            if start and end:
+            if (start is not None) and (end is not None):
                 return self.project.keys[start:end]
+            elif start is not None:
+                return self.project.keys[start]
             else:
                 return self.project.keys
         elif self.project_cfg.type == "ot_trace_library":
@@ -120,8 +127,10 @@ class SCAProject:
         """ Get plaintexts[start, end] from project.
         """
         if self.project_cfg.type == "cw":
-            if start and end:
+            if (start is not None) and (end is not None):
                 return self.project.textins[start:end]
+            elif start is not None:
+                return self.project.textins[start]
             else:
                 return self.project.textins
         elif self.project_cfg.type == "ot_trace_library":


### PR DESCRIPTION
Previously, retrieving parts of a dataset (e.g., plaintext, ciphertext, ...) did not work as there was a bug in the array slicing logic.

Basically, if start and end or end was not provided, "None" is the default value. However, the check in the if condition should be `if (start is not None)` and not `if (start)`.

This PR fixes this issue.

Moreover, now it is also possible to select a single entry of a dataset, e.g., `get_plaintexts(0)` returns the plaintext at DB ID 0.