### PR TITLE
[capture] Update uJSON binaries

### DIFF
--- a/capture/configs/aes_sca_cw310.yaml
+++ b/capture/configs/aes_sca_cw310.yaml
@@ -3,7 +3,7 @@ target:
   fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
   force_program_bitstream: False
   fw_bin: "../objs/aes_serial_fpga_cw310.bin"
-  # fw_bin: "../objs/aes_ujson_fpga_cw310.bin"
+  # fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
   # target_clk_mult is a hardcoded value in the bitstream. Do not change.
   target_clk_mult: 0.24
   target_freq: 24000000

--- a/capture/configs/kmac_sca_cw310.yaml
+++ b/capture/configs/kmac_sca_cw310.yaml
@@ -3,7 +3,7 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: ../objs/kmac_serial_fpga_cw310.bin
-  # fw_bin: "../objs/kmac_ujson_fpga_cw310.bin"
+  # fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
   # target_clk_mult is a hardcoded value in the bitstream. Do not change.
   target_clk_mult: 0.24
   target_freq: 24000000

--- a/capture/configs/sha3_sca_cw310.yaml
+++ b/capture/configs/sha3_sca_cw310.yaml
@@ -3,7 +3,7 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: ../objs/sha3_serial_fpga_cw310.bin
-  # fw_bin: ../objs/sha3_ujson_fpga_cw310.bin
+  # fw_bin: ../objs/sca_ujson_fpga_cw310.bin
   target_clk_mult: 0.24
   target_freq: 24000000
   baudrate: 115200

--- a/capture/configs/sha3_sca_cw310_masks_off.yaml
+++ b/capture/configs/sha3_sca_cw310_masks_off.yaml
@@ -3,7 +3,7 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: ../objs/sha3_serial_fpga_cw310.bin
-  # fw_bin: ../objs/sha3_ujson_fpga_cw310.bin
+  # fw_bin: ../objs/sca_ujson_fpga_cw310.bin
   target_clk_mult: 0.24
   target_freq: 24000000
   baudrate: 115200

--- a/ci/cfg/ci_kmac_sca_fvsr_cw310_simpleserial.yaml
+++ b/ci/cfg/ci_kmac_sca_fvsr_cw310_simpleserial.yaml
@@ -3,7 +3,7 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: ../objs/kmac_serial_fpga_cw310.bin
-  # fw_bin: "../objs/kmac_ujson_fpga_cw310.bin"
+  # fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
   # target_clk_mult is a hardcoded value in the bitstream. Do not change.
   target_clk_mult: 0.24
   target_freq: 24000000

--- a/ci/cfg/ci_kmac_sca_fvsr_cw310_ujson.yaml
+++ b/ci/cfg/ci_kmac_sca_fvsr_cw310_ujson.yaml
@@ -3,7 +3,7 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   # fw_bin: ../objs/kmac_serial_fpga_cw310.bin
-  fw_bin: "../objs/kmac_ujson_fpga_cw310.bin"
+  fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
   # target_clk_mult is a hardcoded value in the bitstream. Do not change.
   target_clk_mult: 0.24
   target_freq: 24000000

--- a/ci/cfg/ci_kmac_sca_random_cw310_simpleserial.yaml
+++ b/ci/cfg/ci_kmac_sca_random_cw310_simpleserial.yaml
@@ -3,7 +3,7 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: ../objs/kmac_serial_fpga_cw310.bin
-  # fw_bin: "../objs/kmac_ujson_fpga_cw310.bin"
+  # fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
   # target_clk_mult is a hardcoded value in the bitstream. Do not change.
   target_clk_mult: 0.24
   target_freq: 24000000

--- a/ci/cfg/ci_kmac_sca_random_cw310_ujson.yaml
+++ b/ci/cfg/ci_kmac_sca_random_cw310_ujson.yaml
@@ -3,7 +3,7 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   # fw_bin: ../objs/kmac_serial_fpga_cw310.bin
-  fw_bin: "../objs/kmac_ujson_fpga_cw310.bin"
+  fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
   # target_clk_mult is a hardcoded value in the bitstream. Do not change.
   target_clk_mult: 0.24
   target_freq: 24000000

--- a/ci/cfg/ci_sha3_sca_fvsr_cw310_simpleserial.yaml
+++ b/ci/cfg/ci_sha3_sca_fvsr_cw310_simpleserial.yaml
@@ -3,7 +3,7 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: ../objs/sha3_serial_fpga_cw310.bin
-  # fw_bin: ../objs/sha3_ujson_fpga_cw310.bin
+  # fw_bin: ../objs/sca_ujson_fpga_cw310.bin
   target_clk_mult: 0.24
   target_freq: 24000000
   baudrate: 115200

--- a/ci/cfg/ci_sha3_sca_fvsr_cw310_ujson.yaml
+++ b/ci/cfg/ci_sha3_sca_fvsr_cw310_ujson.yaml
@@ -3,7 +3,7 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   # fw_bin: ../objs/sha3_serial_fpga_cw310.bin
-  fw_bin: ../objs/sha3_ujson_fpga_cw310.bin
+  fw_bin: ../objs/sca_ujson_fpga_cw310.bin
   target_clk_mult: 0.24
   target_freq: 24000000
   baudrate: 115200

--- a/ci/cfg/ci_sha3_sca_random_cw310_simpleserial.yaml
+++ b/ci/cfg/ci_sha3_sca_random_cw310_simpleserial.yaml
@@ -3,7 +3,7 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   fw_bin: ../objs/sha3_serial_fpga_cw310.bin
-  # fw_bin: ../objs/sha3_ujson_fpga_cw310.bin
+  # fw_bin: ../objs/sca_ujson_fpga_cw310.bin
   target_clk_mult: 0.24
   target_freq: 24000000
   baudrate: 115200

--- a/ci/cfg/ci_sha3_sca_random_cw310_ujson.yaml
+++ b/ci/cfg/ci_sha3_sca_random_cw310_ujson.yaml
@@ -3,7 +3,7 @@ target:
   fpga_bitstream: ../objs/lowrisc_systems_chip_earlgrey_cw310_0.1_kmac_dom.bit
   force_program_bitstream: False
   # fw_bin: ../objs/sha3_serial_fpga_cw310.bin
-  fw_bin: ../objs/sha3_ujson_fpga_cw310.bin
+  fw_bin: ../objs/sca_ujson_fpga_cw310.bin
   target_clk_mult: 0.24
   target_freq: 24000000
   baudrate: 115200

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -307,15 +307,22 @@ OpenTitan using the CW310, follow these steps:
     ```
    and will be loaded to the FPGA using the ChipWhisperer Python API.
 
-1. To generate the OpenTitan application binary, e.g., for recording AES power traces on the CW310, run
+1. To generate the OpenTitan application binary (simpleserial interface), e.g.,
+   for recording AES power traces on the CW310, run
     ```console
     $ cd $REPO_TOP
     $ ./bazelisk.sh build //sw/device/sca:aes_serial
     ```
-The path to the generated binary is:
-```
-$REPO_TOP/bazel-bin/sw/device/sca/
-```
+   The path to the generated binary is:
+   ```
+   $REPO_TOP/bazel-bin/sw/device/sca/
+   ```
+   To generate the OpenTitan application binary for uJSON that includes all SCA
+   targets, run
+    ```console
+    $ cd $REPO_TOP
+    $ ./bazelisk.sh build //sw/device/tests/crypto/cryptotest/firmware:firmware
+    ```
 
 #### English Breakfast for CW305
 

--- a/objs/aes_ujson_fpga_cw310.bin
+++ b/objs/aes_ujson_fpga_cw310.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b743dd09fcee193f59d74948b6c4ddd9b21b734c4b5cd32f3f7eb8905f53e277
-size 61920

--- a/objs/kmac_ujson_fpga_cw310.bin
+++ b/objs/kmac_ujson_fpga_cw310.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3fa15e2be37805e666b30f4258695a13ee0523a374f3004360329b30507a3d3
-size 70064

--- a/objs/sca_ujson_fpga_cw310.bin
+++ b/objs/sca_ujson_fpga_cw310.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b73e2277a93ebe6bbbd6666dc9566b7bdb52043d06c956f42270e9d4b5e9e88
+size 204832

--- a/objs/sha3_ujson_fpga_cw310.bin
+++ b/objs/sha3_ujson_fpga_cw310.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:119ce6753d6e2db2c08389c6b7343421920ddafc555c97f4e48c962199dfb0bd
-size 70704


### PR DESCRIPTION
As the KMAC, SHA3, and AES SCA applications are collected in the same uJSON binary, this PR removes the individual uJSON binaries used so far and replaces them with the combined sca_ujson_fpga_cw310 binary.  In addition, this update is needed as some binaries previously did not had access to the SW trigger, which is needed for tests on discrete. This binary was generated from OpenTitan commit: [b2d9b8356aa72164fb828e60ca8118495df6669d](https://github.com/lowRISC/opentitan/commit/b2d9b8356aa72164fb828e60ca8118495df6669d) with the command:
`bazel build //sw/device/tests/crypto/cryptotest/firmware:firmware`