### PR TITLE
[ci] Reduce number of traces

### DIFF
--- a/ci/cfg/ci_kmac_sca_random_cw310_simpleserial.yaml
+++ b/ci/cfg/ci_kmac_sca_random_cw310_simpleserial.yaml
@@ -33,7 +33,7 @@ husky:
   scope_gain: 26
 capture:
   scope_select: husky
-  num_traces: 1000
+  num_traces: 100
   show_plot: True
   plot_traces: 100
   trace_image_filename: projects/sample_traces_kmac.html

--- a/ci/cfg/ci_kmac_sca_random_cw310_ujson.yaml
+++ b/ci/cfg/ci_kmac_sca_random_cw310_ujson.yaml
@@ -33,7 +33,7 @@ husky:
   scope_gain: 26
 capture:
   scope_select: husky
-  num_traces: 1000
+  num_traces: 100
   show_plot: True
   plot_traces: 100
   trace_image_filename: projects/sample_traces_kmac.html


### PR DESCRIPTION
This PR reduces the number of traces to be recorded from 1000 to 100 for non-batch tests. For testing whether capture works, this is still enough and it speeds up CI.