### PR TITLE
[analysis] Fix title parsing in TVLA

### DIFF
--- a/analysis/tvla.py
+++ b/analysis/tvla.py
@@ -859,7 +859,7 @@ def run_tvla(ctx: typer.Context):
                                     single_trace, threshold, num_samples,
                                     sample_start, metadata)
 
-            title = "TVLA of " + (cfg["project_file"]).rsplit('/')[3]
+            title = "TVLA of " + (cfg["project_file"]).rsplit('/', 1)[-1]
             # Catch case where datetime data isn't saved to project file (e.g. older measurement)
             try:
                 title = title + "\n" + "Captured: " + metadata['datetime']


### PR DESCRIPTION
Previously, the TVLA script made assumption on how the project filename is formated, i.e.,
'../capture/projects/simple_capture_aes_sca'. This PR changes the parsing of this filename to also allow other filename formats.