### PR TITLE
[tvla] Enable re-plotting of figures

### DIFF
--- a/analysis/tvla.py
+++ b/analysis/tvla.py
@@ -668,7 +668,12 @@ def run_tvla(ctx: typer.Context):
 
     elif cfg["ttest_step_file"] is not None:
         # Load previously generated t-test results.
-        ttest_step_file = np.load(cfg["ttest_step_file"])
+        ttest_step_file = np.load(cfg["ttest_step_file"], allow_pickle=True)
+        metadata = ttest_step_file['metadata'].item()
+        sample_start = ttest_step_file['sample_start']
+        single_trace = ttest_step_file['single_trace']
+        trace_start_vec = ttest_step_file['trace_start_vec']
+        num_traces = ttest_step_file['num_traces']
         ttest_step = ttest_step_file['ttest_step']
         num_orders = ttest_step.shape[0]
         num_samples = ttest_step.shape[3]
@@ -701,6 +706,10 @@ def run_tvla(ctx: typer.Context):
             log.info("Saving T-test Step")
             np.savez_compressed('tmp/ttest-step.npy',
                                 ttest_step=ttest_step,
+                                num_traces=num_traces,
+                                metadata=metadata,
+                                sample_start=sample_start,
+                                trace_start_vec=trace_start_vec,
                                 trace_end_vec=trace_end_vec,
                                 rnd_list=rnd_list,
                                 byte_list=byte_list,


### PR DESCRIPTION
This PR adds metadata to the ttest_step_file that is needed to re-printing the figure.

A ttest_step_file can be created by setting passing the `--save-to-disk-ttest` argument to the tvla script. Make sure that `number_of_steps > 1`. To re-generate the figures, the ttest_step_file, which is stored in `tmp/ttest-step.npy.npz`, can be loaded using the argument `--ttest-step-file`.

Closes #284