### PR TITLE
[sca] Fix ACK for uJSON SHA3

### DIFF
--- a/target/communication/sca_sha3_commands.py
+++ b/target/communication/sca_sha3_commands.py
@@ -46,14 +46,13 @@ class OTSHA3:
             if "RESP_OK" in read_line:
                 json_string = read_line.split("RESP_OK:")[1].split(" CRC:")[0]
                 try:
-                    status = json.loads(json_string)["status"]
-                    if status[0] != 0:
-                        raise Exception("Acknowledge error: Device and host not in sync")
-                    return status
+                    if "status" in json_string:
+                        status = json.loads(json_string)["status"]
+                        if status[0] != 0:
+                            raise Exception("Acknowledge error: Device and host not in sync")
+                        return status
                 except Exception:
                     raise Exception("Acknowledge error: Device and host not in sync")
-            else:
-                raise Exception("Acknowledge error: Device and host not in sync")
 
     def set_mask_off(self):
         if self.simple_serial:


### PR DESCRIPTION
This PR should fix the 'Acknowledge error: Device and host not in sync' error message that occasionally occured in the CI for SHA3 measurements when using uJSON.

With this change, the _ujson_sha3_sca_ack waits now until the ACK flag is received. If the device is, for some reason, really not responding, the readline() function times out and the exception is raised.

Closes #283