### PR TITLE
[tvla] Enable TVLA general-data analysis

### DIFF
--- a/analysis/configs/tvla_cfg_aes_specific_byte0_rnd0.yaml
+++ b/analysis/configs/tvla_cfg_aes_specific_byte0_rnd0.yaml
@@ -1,4 +1,4 @@
-project_file: ../capture/projects/simple_capture_aes_sca
+project_file: ../capture/projects/aes_fvsr_key_cw310
 trace_file: null
 trace_start: null
 trace_end: null
@@ -12,7 +12,7 @@ output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: true
-general_test: false
+test_type: "SPECIFIC"
 mode: aes
 filter_traces: true
 trace_threshold: 1000

--- a/analysis/configs/tvla_cfg_kmac.yaml
+++ b/analysis/configs/tvla_cfg_kmac.yaml
@@ -12,7 +12,7 @@ output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: true
-general_test: true
+test_type: "GENERAL_KEY"
 mode: kmac
 filter_traces: true
 trace_threshold: 1000

--- a/analysis/configs/tvla_cfg_otbn_keygen.yaml
+++ b/analysis/configs/tvla_cfg_otbn_keygen.yaml
@@ -12,7 +12,7 @@ output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: true
-general_test: true
+test_type: "GENERAL_KEY"
 mode: otbn
 key_len_bytes: 40
 sample_start: null

--- a/analysis/configs/tvla_cfg_otbn_modinv.yaml
+++ b/analysis/configs/tvla_cfg_otbn_modinv.yaml
@@ -12,7 +12,7 @@ output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: true
-general_test: true
+test_type: "GENERAL_KEY"
 mode: otbn
 key_len_bytes: 32
 sample_start: null

--- a/analysis/configs/tvla_cfg_sha3.yaml
+++ b/analysis/configs/tvla_cfg_sha3.yaml
@@ -12,7 +12,7 @@ output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: true
-general_test: true
+test_type: "GENERAL_DATA"
 mode: sha3
 filter_traces: true
 trace_threshold: 1000

--- a/analysis/configs/tvla_cfg_sha3_masks_off.yaml
+++ b/analysis/configs/tvla_cfg_sha3_masks_off.yaml
@@ -12,5 +12,5 @@ output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: true
-general_test: true
+test_type: "GENERAL_DATA"
 mode: sha3

--- a/analysis/configs/tvla_cfg_template.yaml
+++ b/analysis/configs/tvla_cfg_template.yaml
@@ -12,7 +12,7 @@ output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: false
-general_test: true
+test_type: "GENERAL_KEY"
 mode: aes
 # Only enabled for otbn mode.
 sample_start: null

--- a/ci/cfg/ci_tvla_cfg_aes_specific_byte0_rnd0.yaml
+++ b/ci/cfg/ci_tvla_cfg_aes_specific_byte0_rnd0.yaml
@@ -12,7 +12,7 @@ output_histogram_file: null
 number_of_steps: 1
 ttest_step_file: null
 plot_figures: true
-general_test: false
+test_type: "SPECIFIC"
 mode: aes
 filter_traces: true
 trace_threshold: 1000

--- a/ci/cfg/ci_tvla_cfg_aes_specific_byte_0_15_rnd_0_1.yaml
+++ b/ci/cfg/ci_tvla_cfg_aes_specific_byte_0_15_rnd_0_1.yaml
@@ -12,7 +12,7 @@ output_histogram_file: null
 number_of_steps: 4
 ttest_step_file: null
 plot_figures: true
-general_test: false
+test_type: "SPECIFIC"
 mode: aes
 filter_traces: false
 sample_start: 0

--- a/test/tvla_test.py
+++ b/test/tvla_test.py
@@ -43,7 +43,7 @@ def ttest_compare_results(expected, received, delta) -> bool:
 def test_general_kmac_nonleaking_project():
     project_path = TestDataPath('tvla_general/ci_opentitan_simple_kmac.cwp')
     tvla = TvlaCmd(Args(['--project-file', str(project_path),
-                         '--mode', 'kmac', '--save-to-disk-ttest', '--general-test',
+                         '--mode', 'kmac', '--save-to-disk-ttest', '--test-type', 'GENERAL_KEY',
                          '--number-of-steps', '10', 'run-tvla'])).run()
     expected_path = TestDataPath('tvla_general/ttest-step-golden-kmac.npy.npz')
     expected_file = np.load(str(expected_path))
@@ -61,7 +61,7 @@ def test_general_kmac_nonleaking_project():
 def test_general_aes_nonleaking_project():
     project_path = TestDataPath('tvla_general/ci_opentitan_simple_aes_fvsr.cwp')
     tvla = TvlaCmd(Args(['--project-file', str(project_path),
-                         '--mode', 'aes', '--save-to-disk-ttest', '--general-test',
+                         '--mode', 'aes', '--save-to-disk-ttest', '--test-type', 'GENERAL_KEY',
                          '--number-of-steps', '10', 'run-tvla'])).run()
     expected_path = TestDataPath('tvla_general/ttest-step-golden-aes.npy.npz')
     expected_file = np.load(str(expected_path))
@@ -76,7 +76,7 @@ def test_general_aes_nonleaking_project():
 def test_general_leaking_histogram():
     hist_path = TestDataPath('tvla_general/kmac_hist_leaking.npz')
     tvla = TvlaCmd(Args(['--input-histogram-file', str(hist_path),
-                        '--mode', 'kmac', '--save-to-disk-ttest', '--general-test',
+                        '--mode', 'kmac', '--save-to-disk-ttest', '--test-type', 'GENERAL_KEY',
                          'run-tvla'])).run()
     assert ttest_significant(np.load('tmp/ttest.npy')), (
            f"{tvla} did not find significant leakage, which is unexpected")
@@ -85,7 +85,7 @@ def test_general_leaking_histogram():
 def test_general_nonleaking_histogram():
     hist_path = TestDataPath('tvla_general/kmac_hist_nonleaking.npz')
     tvla = TvlaCmd(Args(['--input-histogram-file', str(hist_path),
-                        '--mode', 'kmac', '--save-to-disk-ttest', '--general-test',
+                        '--mode', 'kmac', '--save-to-disk-ttest', '--test-type', 'GENERAL_KEY',
                          'run-tvla'])).run()
     assert not ttest_significant(np.load('tmp/ttest.npy')), (
            f"{tvla} did find significant leakage, which is unexpected")
@@ -95,7 +95,8 @@ def test_aes_byte_filtering():
     project_path = TestDataPath('tvla_aes_byte/ci_opentitan_simple_aes.cwp')
     tvla = TvlaCmd(Args(['--project-file', str(project_path),
                          '--mode', 'aes', '--round-select', '0',
-                         '--byte-select', '0', '--save-to-disk', 'run-tvla'])).run()
+                         '--byte-select', '0', '--save-to-disk', '--test-type', 'SPECIFIC',
+                         'run-tvla'])).run()
     received_file = np.load('tmp/traces.npy.npz')
     traces_to_use = received_file['traces_to_use']
     assert sum(traces_to_use) <= 100, (

--- a/util/leakage_models.py
+++ b/util/leakage_models.py
@@ -79,31 +79,31 @@ def compute_leakage_aes(keys, plaintexts, leakage_model = 'HAMMING_WEIGHT'):
     return leakage
 
 
-def find_fixed_key(keys):
+def find_fixed_entry(dataset):
     """
-    Finds a fixed key.
+    Finds a fixed entry (key or plaintext).
 
-    In a fixed-vs-random analysis, only fixed_key will repeat multiple times,
-    this will not necesserily be the first key on the list.
-    This function looks at the input list of keys and finds the first one that
+    In a fixed-vs-random analysis, only fixed_entry will repeat multiple times,
+    this will not necesserily be the first entry on the list.
+    This function looks at the input list and finds the first entry that
     is repeated multiple times.
     """
 
-    for i_key in range(len(keys)):
-        fixed_key = keys[i_key]
+    for i_entry in range(len(dataset)):
+        fixed_entry = dataset[i_entry]
         num_hits = 0
-        for i in range(len(keys)):
-            num_hits += np.array_equal(fixed_key, keys[i])
+        for i in range(len(dataset)):
+            num_hits += np.array_equal(fixed_entry, dataset[i])
         if num_hits > 1:
             break
 
-    # If no key repeats, then the fixed key cannot be identified.
-    assert num_hits > 1, "Cannot identify fixed key. Try using a longer list."
+    # If no entry repeats, then the fixed entry cannot be identified.
+    assert num_hits > 1, "Cannot identify fixed entry. Try using a longer list."
 
-    return fixed_key
+    return fixed_entry
 
 
-def compute_leakage_general(keys, fixed_key):
+def compute_leakage_general(dataset, fixed_entry):
     """
     Computes leakage for TVLA fixed-vs-random general attaks.
 
@@ -113,8 +113,8 @@ def compute_leakage_general(keys, fixed_key):
         leakage[i] = 0 - trace i belonges to the random group
     """
 
-    leakage = np.zeros((len(keys)), dtype=np.uint8)
-    for i in range(len(keys)):
-        leakage[i] = np.array_equal(fixed_key, keys[i])
+    leakage = np.zeros((len(dataset)), dtype=np.uint8)
+    for i in range(len(dataset)):
+        leakage[i] = np.array_equal(fixed_entry, dataset[i])
 
     return leakage


### PR DESCRIPTION
This commit enables TVLA fixed-vs-random data analysis. In addition, this commit re-names related functions and variables to more accurate and intuitive names.

The main change is in `tvla.py`
The remaining changes are mostly in configuration files due to changing parameter from boolean `general_test` to string `test_type` in `"GENERAL_KEY", "GENERAL_DATA", "SPECIFIC"`.