### PR TITLE
[capture] Reset device on no response

### DIFF
--- a/target/chip.py
+++ b/target/chip.py
@@ -35,7 +35,7 @@ class Chip():
             time.sleep(self.boot_delay)
             print(f'Info: OpenTitan flashed with {self.firmware}.')
 
-    def target_reset(self, boot_delay: Optional[int] = 1):
+    def reset_target(self, boot_delay: Optional[int] = 1):
         """Reset OpenTitan by triggering the reset pin using opentitantool."""
         reset_process = Popen([self.opentitantool, "--rcfile=",
                                "--interface=hyper310",


### PR DESCRIPTION
When no response is received from the device, restart it and try again. This is helpful to avoid that a single missed response from the device requires us to throw away the entire capture results.

Currently only implemented for SHA3 to test the code.