### PR TITLE
[scope] Set WaveRunner short command header

### DIFF
--- a/capture/scopes/waverunner/waverunner.py
+++ b/capture/scopes/waverunner/waverunner.py
@@ -87,6 +87,9 @@ class WaveRunner:
         self._populate_device_info()
         self._print_device_info()
         self.acqu_channel = "C3"
+        # Configure scope to acknowledge commands with a short command header.
+        res = self._ask("CHDR SHORT;*OPC?")
+        assert res == "*OPC 1"
 
     @property
     def num_segments_max(self):


### PR DESCRIPTION
When using the WaveStudio GUI to access the scope, this application reconfigures the format of the command responses to CHDR=OFF, i.e., there is no header. However, the Waverunner driver we are using requires that the commands are acknowledged in the header using CHDR=SHORT.