### PR TITLE
[capture] Re-add force_program_bitstream to target_cfg

### DIFF
--- a/capture/capture_aes.py
+++ b/capture/capture_aes.py
@@ -98,6 +98,7 @@ def setup(cfg: dict, project: Path):
         protocol = cfg["target"]["protocol"],
         pll_frequency = cfg["target"]["pll_frequency"],
         bitstream = cfg["target"].get("fpga_bitstream"),
+        force_program_bitstream = cfg["target"].get("force_program_bitstream"),
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes")

--- a/capture/capture_kmac.py
+++ b/capture/capture_kmac.py
@@ -102,6 +102,7 @@ def setup(cfg: dict, project: Path):
         protocol = cfg["target"]["protocol"],
         pll_frequency = cfg["target"]["pll_frequency"],
         bitstream = cfg["target"].get("fpga_bitstream"),
+        force_program_bitstream = cfg["target"].get("force_program_bitstream"),
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes")

--- a/capture/capture_otbn.py
+++ b/capture/capture_otbn.py
@@ -112,6 +112,7 @@ def setup(cfg: dict, project: Path):
         protocol = cfg["target"]["protocol"],
         pll_frequency = cfg["target"]["pll_frequency"],
         bitstream = cfg["target"].get("fpga_bitstream"),
+        force_program_bitstream = cfg["target"].get("force_program_bitstream"),
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes")

--- a/capture/capture_sha3.py
+++ b/capture/capture_sha3.py
@@ -87,6 +87,7 @@ def setup(cfg: dict, project: Path):
         protocol = cfg["target"]["protocol"],
         pll_frequency = cfg["target"]["pll_frequency"],
         bitstream = cfg["target"].get("fpga_bitstream"),
+        force_program_bitstream = cfg["target"].get("force_program_bitstream"),
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes")

--- a/fault_injection/fi_ibex.py
+++ b/fault_injection/fi_ibex.py
@@ -43,6 +43,7 @@ def setup(cfg: dict, project: Path):
         protocol = cfg["target"]["protocol"],
         pll_frequency = cfg["target"]["pll_frequency"],
         bitstream = cfg["target"].get("fpga_bitstream"),
+        force_program_bitstream = cfg["target"].get("force_program_bitstream"),
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes")


### PR DESCRIPTION
This parameter got somehow dropped and was no longer read from the capture config file. As a result, we were always using the same bitstreams. For example, the SHA3 measurements produce the following CI artifact:

![bokeh_plot_faulty](https://github.com/lowRISC/ot-sca/assets/20307557/711d0734-e7f1-4411-ad46-0a1840ff8419)

Whereas the correct plot would look like this (generated locally using the "same" bitstream and binary):

![bokeh_plot_correct](https://github.com/lowRISC/ot-sca/assets/20307557/c1b31ff3-9695-411f-aa06-76edfc3bc05a)

The active portion of the trace is 4x longer as the masked SHA3 takes 4 cycles per round vs. 1 cycle for the unmasked implementation.