### PR TITLE
[chip] Add support for multiple chips

### DIFF
--- a/capture/capture_aes.py
+++ b/capture/capture_aes.py
@@ -101,7 +101,8 @@ def setup(cfg: dict, project: Path):
         force_program_bitstream = cfg["target"].get("force_program_bitstream"),
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
-        output_len = cfg["target"].get("output_len_bytes")
+        output_len = cfg["target"].get("output_len_bytes"),
+        usb_serial = cfg["target"].get("usb_serial")
     )
     target = Target(target_cfg)
 

--- a/capture/capture_kmac.py
+++ b/capture/capture_kmac.py
@@ -105,7 +105,8 @@ def setup(cfg: dict, project: Path):
         force_program_bitstream = cfg["target"].get("force_program_bitstream"),
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
-        output_len = cfg["target"].get("output_len_bytes")
+        output_len = cfg["target"].get("output_len_bytes"),
+        usb_serial = cfg["target"].get("usb_serial")
     )
     target = Target(target_cfg)
 

--- a/capture/capture_otbn.py
+++ b/capture/capture_otbn.py
@@ -115,7 +115,8 @@ def setup(cfg: dict, project: Path):
         force_program_bitstream = cfg["target"].get("force_program_bitstream"),
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
-        output_len = cfg["target"].get("output_len_bytes")
+        output_len = cfg["target"].get("output_len_bytes"),
+        usb_serial = cfg["target"].get("usb_serial")
     )
     target = Target(target_cfg)
 

--- a/capture/capture_sha3.py
+++ b/capture/capture_sha3.py
@@ -90,7 +90,8 @@ def setup(cfg: dict, project: Path):
         force_program_bitstream = cfg["target"].get("force_program_bitstream"),
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
-        output_len = cfg["target"].get("output_len_bytes")
+        output_len = cfg["target"].get("output_len_bytes"),
+        usb_serial = cfg["target"].get("usb_serial")
     )
     target = Target(target_cfg)
 

--- a/fault_injection/fi_ibex.py
+++ b/fault_injection/fi_ibex.py
@@ -46,7 +46,8 @@ def setup(cfg: dict, project: Path):
         force_program_bitstream = cfg["target"].get("force_program_bitstream"),
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
-        output_len = cfg["target"].get("output_len_bytes")
+        output_len = cfg["target"].get("output_len_bytes"),
+        usb_serial = cfg["target"].get("usb_serial")
     )
     target = Target(target_cfg)
 

--- a/target/targets.py
+++ b/target/targets.py
@@ -27,6 +27,7 @@ class TargetConfig:
     baudrate: Optional[int] = None
     port: Optional[str] = None
     read_timeout: Optional[int] = 1
+    usb_serial: Optional[str] = None
 
 
 class Target:
@@ -58,7 +59,8 @@ class Target:
             )
         elif self.target_cfg.target_type == "chip":
             target = Chip(firmware = self.target_cfg.fw_bin,
-                          opentitantool_path = "../target/lib/opentitantool")
+                          opentitantool_path = "../target/lib/opentitantool",
+                          usb_serial=self.target_cfg.usb_serial)
         else:
             raise RuntimeError("Error: Target not supported!")
         return target


### PR DESCRIPTION
This PR adds support for having multiple chips attached to the computer. By providing the serial number of the chip using the "usb_serial:: entry in the config files, ot-sca is capable of programming the correct device.