### PR TITLE
[capture] Add FPGA mode for AES

### DIFF
--- a/capture/capture_aes.py
+++ b/capture/capture_aes.py
@@ -188,6 +188,14 @@ def configure_cipher(cfg, capture_cfg, ot_aes, ot_prng):
         ot_aes: The communication interface to the AES SCA application.
         ot_prng: The communication interface to the PRNG SCA application.
     """
+    # Check if we want to run AES SCA for FPGA or discrete. On the FPGA, we
+    # can use functionality helping us to capture cleaner traces.
+    fpga_mode_bit = 0
+    if "cw" in cfg["target"]["target_type"]:
+        fpga_mode_bit = 1
+    # Initialize AES on the target.
+    ot_aes.init(fpga_mode_bit)
+
     # Configure PRNGs.
     # Seed the software LFSR used for initial key masking and additionally
     # turning off the masking when '0'.

--- a/objs/sca_ujson_fpga_cw310.bin
+++ b/objs/sca_ujson_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e58fc18357185c5c47feaa6d8fcb6dce97af1517c91ce56aed8683dde9ffe3c
-size 215620
+oid sha256:9677a472d723de146c5930f1acdcd0dda6f9cc465505f92e2ca9dea5f2a194fc
+size 251372

--- a/target/communication/sca_aes_commands.py
+++ b/target/communication/sca_aes_commands.py
@@ -17,15 +17,27 @@ class OTAES:
         self.simple_serial = True
         if protocol == "ujson":
             self.simple_serial = False
-            # Init the AES core.
-            self.target.write(json.dumps("AesSca").encode("ascii"))
-            self.target.write(json.dumps("Init").encode("ascii"))
 
     def _ujson_aes_sca_cmd(self):
         # TODO: without the delay, the device uJSON command handler program
         # does not recognize the commands. Tracked in issue #256.
         time.sleep(0.01)
         self.target.write(json.dumps("AesSca").encode("ascii"))
+
+    def init(self, fpga_mode_bit: int):
+        """ Initializes AES on the target.
+        Args:
+            fpga_mode_bit: Indicates whether FPGA specific AES test is started.
+        """
+        if not self.simple_serial:
+            # AesSca command.
+            self._ujson_aes_sca_cmd()
+            # Init the AES core.
+            self.target.write(json.dumps("Init").encode("ascii"))
+            # FPGA mode.
+            time.sleep(0.01)
+            fpga_mode = {"fpga_mode": fpga_mode_bit}
+            self.target.write(json.dumps(fpga_mode).encode("ascii"))
 
     def key_set(self, key: list[int], key_length: Optional[int] = 16):
         """ Write key to AES.


### PR DESCRIPTION
On the FPGA, the AES core automatically raises the SCA trigger we are using for capturing traces. However, on the chip this functionality is disabled.

This PR transmits the fpga_mode bit to the code running on the FPGA or the chip. Based on this bit, the target code either manually raises the trigger or lets the AES core handle automatically the trigger.

The target code is available in https://github.com/lowRISC/opentitan/pull/21741 and the binary
sca_ujson_fpga_cw310 was created using this PR and the command:
./bazelisk.sh build //sw/device/tests/crypto/cryptotest/firmware:firmware