### PR TITLE
[analysis] Trace aligning using mean trace

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -648,14 +648,14 @@ captured with the OpenTitan trace library. This script provides two functionalit
 
 The filtering can be enabled with the `-f` command line argument and the tolerable deviation
 from average with `-s`.
-To turn on the trace aligning mechanism, use the `-a` flag. The reference trace is
-defined with `-r` and the window can be specified with `-lw` and `-hw`.
+To turn on the trace aligning mechanism, use the `-a` flag. The reference trace is calculated
+from the mean of `-n` traces and the window can be specified with `-lw` and `-hw`.
 When operating with larger databases, the `-m` parameter can be used to specify the
 maximum amount of traces that are kept in memory.
 An example is shown below:
 
 ```console
-$ ./trace_preprocessing.py -i db_in.db -o db_out.db -f -s 7.5 -a -p 5 -r 1 -lw 21000 -hw 23000 -ms 20 -m 1000
+$ ./trace_preprocessing.py -i db_in.db -o db_out.db -f -s 7.5 -a -p 5 -n 1000 -lw 21000 -hw 23000 -ms 20 -m 1000
 ```
 
 # Troubleshooting

--- a/util/plot.py
+++ b/util/plot.py
@@ -15,7 +15,8 @@ from bokeh.plotting import figure, show
 from fault_injection.project_library.project import FISuccess
 
 
-def save_plot_to_file(traces, set_indices, num_traces, outfile, add_mean_stddev=False):
+def save_plot_to_file(traces, set_indices, num_traces, outfile,
+                      add_mean_stddev=False, ref_trace=None):
     """Save plot figure to file."""
     if set_indices is None:
         colors = itertools.cycle(palette)
@@ -34,12 +35,15 @@ def save_plot_to_file(traces, set_indices, num_traces, outfile, add_mean_stddev=
     plot.add_tools(tools.HoverTool())
     for i in range(min(len(traces), num_traces)):
         if set_indices is None:
-            if add_mean_stddev:
+            if add_mean_stddev or ref_trace is not None:
                 plot.line(xrange, traces[i], line_color='grey')
             else:
                 plot.line(xrange, traces[i], line_color=next(colors))
         else:
             plot.line(xrange, traces[i], line_color=next(colors), legend_label=str(set_indices[i]))
+
+    if ref_trace is not None:
+        plot.line(xrange, ref_trace, line_color='firebrick', line_width=2, legend_label='mean')
 
     if add_mean_stddev:
         # Add mean and std dev to figure


### PR DESCRIPTION
With this PR, the reference trace for the trace aligning function is determined by calculating the mean over num_traces_mean traces. The reason for that is that the trace aligning function achieves better results by using the mean as a reference trace.