### PR TITLE
[fi] Optimize plot generation

### DIFF
--- a/util/plot.py
+++ b/util/plot.py
@@ -85,17 +85,33 @@ def save_fi_plot_to_file(cfg: dict, fi_results: [], outfile: str) -> None:
                            cfg["fisetup"][y_axis + "_max"]))
     plot.xaxis.axis_label = x_axis + " " + cfg["fiproject"]["plot_x_axis_legend"]
     plot.yaxis.axis_label = y_axis + " " + cfg["fiproject"]["plot_y_axis_legend"]
+
+    exp_x = []
+    exp_y = []
+    unexp_x = []
+    unexp_y = []
+    no_x = []
+    no_y = []
     for fi_result in fi_results:
-        color = "red"
-        label = "No response"
+        fi_result_dict = dataclasses.asdict(fi_result)
         if fi_result.fi_result == FISuccess.SUCCESS:
-            color = "green"
-            label = "Unexpected response"
+            unexp_x.append(fi_result_dict[x_axis])
+            unexp_y.append(fi_result_dict[y_axis])
         elif fi_result.fi_result == FISuccess.EXPRESPONSE:
-            color = "yellow"
-            label = "Expected response"
-        fi_result = dataclasses.asdict(fi_result)
-        plot.scatter(fi_result[x_axis], fi_result[y_axis], legend_label = label,
-                     line_color=color, fill_color=color)
-        plot.scatter()
+            exp_x.append(fi_result_dict[x_axis])
+            exp_y.append(fi_result_dict[y_axis])
+        else:
+            no_x.append(fi_result_dict[x_axis])
+            no_y.append(fi_result_dict[y_axis])
+
+    if unexp_x:
+        plot.scatter(unexp_x, unexp_y, line_color="green", fill_color="green",
+                     legend_label="Unexpected response")
+    if exp_x:
+        plot.scatter(exp_x, exp_y, line_color="orange", fill_color="orange",
+                     legend_label="Expected response")
+    if no_x:
+        plot.scatter(no_x, no_y, line_color="red", fill_color="red",
+                     legend_label="No response")
+
     show(plot)


### PR DESCRIPTION
This commit optimizes the generation of the FI scatter plot. Instead of calling plot.scatter() for each datapoint, now, an array is passed to the function. With this changes, scatter plots with >100k points can be plotted, which was not possible before this change.