### PR TITLE
Add GitHub Actions FPGA workflow

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -1,0 +1,313 @@
+name: fpga
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+# Cancel running jobs if the branch is updated.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  aes_sca_capture_cw310:
+    name: Capture AES SCA traces (CW310)
+    runs-on: [ubuntu-22.04-fpga, cw310]
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Install python dependencies
+        run: |
+          python3 -m pip install --user -r python-requirements.txt
+          mkdir -p ci/projects
+
+      - name: Capture AES FVSR traces (simpleserial)
+        working-directory: ci
+        run: |
+          ../capture/capture_aes.py -c cfg/ci_aes_sca_fvsr_cw310_simpleserial.yaml -p projects/aes_sca_fvsr_cw310
+
+      - name: Upload AES FVSR traces (simpleserial)
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces_aes_fvsr
+          path: ./ci/projects/aes_sca_fvsr_cw310.html
+
+      - name: Perform TVLA on AES FVSR traces
+        working-directory: ci
+        run: |
+          ../analysis/tvla.py --cfg-file cfg/ci_tvla_cfg_aes_specific_byte0_rnd0.yaml run-tvla
+        continue-on-error: true
+
+      - name: Upload figure of AES TVLA  
+        uses: actions/upload-artifact@v4
+        with:
+          name: tvla_figure
+          path: ./ci/tmp/figures
+
+      - name: Capture AES Random traces (simpleserial)
+        working-directory: ci
+        run: |
+          ../capture/capture_aes.py -c cfg/ci_aes_sca_random_cw310_simpleserial.yaml -p projects/aes_sca_random_cw310
+
+      - name: Upload AES Random traces (simpleserial)
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces_aes_random_key
+          path: ./ci/projects/aes_sca_random_cw310.html
+
+      - name: Compare AES Random traces against golden trace
+        working-directory: ci
+        run: |
+          ./ci_trace_check/ci_compare_aes_traces.py -f ./projects/aes_sca_random_cw310 -g ./ci_trace_check/golden_traces/aes_sca_random_golden_cw310 -c 0.8
+
+      - name: Capture AES FVSR traces (ujson)
+        working-directory: ci
+        run: |
+          ../capture/capture_aes.py -c cfg/ci_aes_sca_fvsr_cw310_ujson.yaml -p projects/aes_sca_fvsr_cw310_ujson
+
+      - name: Upload AES FVSR traces (ujson)
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces_aes_fvsr_ujson
+          path: ./ci/projects/aes_sca_fvsr_cw310_ujson.html
+
+      - name: Capture AES Random traces (ujson)
+        working-directory: ci
+        run: |
+          ../capture/capture_aes.py -c cfg/ci_aes_sca_random_cw310_ujson.yaml -p projects/aes_sca_random_cw310_ujson
+
+      - name: Upload AES Random traces (ujson)
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./ci/projects/aes_sca_random_cw310_ujson.html
+          name: traces_aes_random_key_ujson
+
+  sha3_sca_capture_cw310:
+    name: Capture SHA3 SCA traces (CW310)
+    runs-on: [ubuntu-22.04-fpga, cw310]
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Install python dependencies
+        run: |
+          python3 -m pip install --user -r python-requirements.txt
+          mkdir -p ci/projects
+
+      - name: Capture SHA3 FVSR traces (simpleserial)
+        working-directory: ci
+        run: |
+          ../capture/capture_sha3.py -c cfg/ci_sha3_sca_fvsr_cw310_simpleserial.yaml -p projects/sha3_sca_fvsr_cw310_simpleserial
+
+      - name: Upload SHA3 FVSR traces (simpleserial)
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces_sha3_fvsr_cw310_simpleserial
+          path: ./ci/projects/sha3_sca_fvsr_cw310_simpleserial.html
+
+      - name: Capture SHA3 FVSR traces (uJSON)
+        working-directory: ci
+        run: |
+          ../capture/capture_sha3.py -c cfg/ci_sha3_sca_fvsr_cw310_ujson.yaml -p projects/sha3_sca_fvsr_cw310_ujson
+
+      - name: Upload SHA3 FVSR traces (uJSON)
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces_sha3_fvsr_cw310_ujson
+          path: ./ci/projects/sha3_sca_fvsr_cw310_ujson.html
+
+      - name: Capture SHA3 Random traces (simpleserial)
+        working-directory: ci
+        run: |
+          ../capture/capture_sha3.py -c cfg/ci_sha3_sca_random_cw310_simpleserial.yaml -p projects/sha3_sca_random_cw310_simpleserial
+
+      - name: Upload SHA3 Random traces (simpleserial)
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces_sha3_random_cw310_simpleserial
+          path: ./ci/projects/sha3_sca_random_cw310_simpleserial.html
+
+      - name: Capture SHA3 Random traces (uJSON)
+        working-directory: ci
+        run: |
+          ../capture/capture_sha3.py -c cfg/ci_sha3_sca_random_cw310_ujson.yaml -p projects/sha3_sca_random_cw310_ujson
+
+      - name: Upload SHA3 Random traces (uJSON)
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces_sha3_random_cw310_ujson
+          path: ./ci/projects/sha3_sca_random_cw310_ujson.html
+
+  sca_capture_cw305:
+    name: Capture AES SCA traces (CW305)
+    runs-on: [ubuntu-22.04-fpga, cw305]
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Install python dependencies
+        run: |
+          python3 -m pip install --user -r python-requirements.txt
+          mkdir -p ci/projects
+
+      - name: Capture AES FVSR traces
+        working-directory: ci
+        run: |
+          ../capture/capture_aes.py -c cfg/ci_aes_sca_fvsr_cw305.yaml -p projects/aes_sca_fvsr_cw305
+
+      - name: Upload AES FVSR traces
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces_aes_fvsr_key_cw305
+          path: ./ci/projects/aes_sca_fvsr_cw305.html
+
+      - name: Capture AES Random traces
+        working-directory: ci
+        run: |
+          ../capture/capture_aes.py -c cfg/ci_aes_sca_random_cw305.yaml -p projects/aes_sca_random_cw305
+
+      - name: Upload AES Random traces
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces_aes_random_cw305
+          path: ./ci/projects/aes_sca_random_cw305.html
+
+      - name: Perform specific TVLA on AES Random traces
+        working-directory: ci
+        run: |
+          ../analysis/tvla.py --cfg-file cfg/ci_tvla_cfg_aes_specific_byte_0_15_rnd_0_1.yaml run-tvla
+        continue-on-error: true
+
+      - name: Upload figures of specific TVLA for AES.
+        uses: actions/upload-artifact@v4
+        with:
+          name: tvla_figures_aes_specific
+          path: ./ci/tmp/figures
+
+  kmac_sca_capture_cw310:
+    name: Capture KMAC SCA traces (CW310)
+    runs-on: [ubuntu-22.04-fpga, cw310]
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Install python dependencies
+        run: |
+          python3 -m pip install --user -r python-requirements.txt
+          mkdir -p ci/projects
+
+      - name: Capture KMAC FVSR traces (simpleserial)
+        working-directory: ci
+        run: |
+          ../capture/capture_kmac.py -c cfg/ci_kmac_sca_fvsr_cw310_simpleserial.yaml -p projects/kmac_sca_fvsr_cw310_simpleserial
+
+      - name: Upload KMAC FVSR traces (simpleserial)
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces_kmac_fvsr_cw310_simpleserial
+          path: ./ci/projects/kmac_sca_fvsr_cw310_simpleserial.html
+
+      - name: Capture KMAC FVSR traces (uJSON)
+        working-directory: ci
+        run: |
+          ../capture/capture_kmac.py -c cfg/ci_kmac_sca_fvsr_cw310_ujson.yaml -p projects/kmac_sca_fvsr_cw310_ujson
+
+      - name: Upload KMAC FVSR traces (uJSON)
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces_kmac_fvsr_cw310_ujson
+          path: ./ci/projects/kmac_sca_fvsr_cw310_ujson.html
+
+      - name: Capture KMAC Random traces (simpleserial)
+        working-directory: ci
+        run: |
+          ../capture/capture_kmac.py -c cfg/ci_kmac_sca_random_cw310_simpleserial.yaml -p projects/kmac_sca_random_cw310_simpleserial
+
+      - name: Upload KMAC Random traces (simpleserial)
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces_kmac_random_cw310_simpleserial
+          path: ./ci/projects/kmac_sca_random_cw310_simpleserial.html
+
+      - name: Capture KMAC Random traces (uJSON)
+        working-directory: ci
+        run: |
+          ../capture/capture_kmac.py -c cfg/ci_kmac_sca_random_cw310_ujson.yaml -p projects/kmac_sca_random_cw310_ujson
+
+      - name: Upload KMAC Random traces (uJSON)
+        uses: actions/upload-artifact@v4
+        with:
+          name: traces_kmac_random_cw310_ujson
+          path: ./ci/projects/kmac_sca_random_cw310_ujson.html
+
+  ceca:
+    name: CECA Attack
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Install python dependencies
+        run: |
+          python3 -m pip install --user -r python-requirements.txt
+
+      - name: CECA with CW and OT Trace Database
+        working-directory: ci
+        run: |
+          ./scripts/check-ceca.sh
+
+  fi_cw310:
+    name: Dummy VCC glitching (CW310)
+    runs-on: [ubuntu-22.04-fpga, cw310]
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Install python dependencies
+        run: |
+          python3 -m pip install --user -r python-requirements.txt
+          mkdir -p ci/projects
+
+      - name: Dummy VCC glitching on Ibex
+        working-directory: ci
+        run: |
+          ../fault_injection/fi_ibex.py -c cfg/ci_ibex_fi_vcc_dummy_cw310.yaml -p projects/ibex_fi_cw310
+
+      - name: Upload FI Ibex CW310 plot
+        uses: actions/upload-artifact@v4
+        with:
+          name: fi_plot_ibex_cw310
+          path: ./ci/projects/ibex_fi_cw310.html
+
+      - name: Dummy VCC glitching on OTBN
+        working-directory: ci
+        run: |
+          ../fault_injection/fi_otbn.py -c cfg/ci_otbn_fi_vcc_dummy_cw310.yaml -p projects/otbn_fi_cw310
+
+      - name: Upload FI OTBN CW310 plot
+        uses: actions/upload-artifact@v4
+        with:
+          name: fi_plot_otbn_cw310
+          path: ./ci/projects/otbn_fi_cw310.html

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -1,33 +1,30 @@
 # Continuous Integration (CI)
 
-This repository has access to a pool of FPGAs in Azure Pipelines for running
-continuous integration tests on.
+This repository has access to a pool of machines that have FPGAs attached and
+can be used to run GitHub Actions continuous integration jobs on.
 
-See [azure-pipelines.yml](../ci/azure-pipelines.yml) for the Azure pipeline
-that currently runs on each pull request.
+See [.github/workflows/fpga.yml](../.github/workflows/fpga.yml) for a GitHub
+Actions workflow that uses these FPGAs and runs on each pull request.
 
 ## Selecting FPGAs
 
-The `FPGA SCA` Azure agent pool contains both a CW305 and CW310 agent.
+The pool of FPGAs contains both a CW305 and CW310 runner.
 
-To run a pipeline job on a particular FPGA, you must specify the board type in
-the YAML specification file:
+To run a job on a machine with a particular FPGA, you must specify either the
+`cw305` or `cw310` labels in addition to `ubuntu-22.04-fpga` in the YAML
+specification file:
 
 ```yaml
 jobs:
-- job: some_cw305_job
-  pool:
-    name: FPGA SCA
-    demands: BOARD -equals cw305
-  steps:
-    - ...
+  some_cw305_job:
+    runs-on: [ubuntu-22.04-fpga, cw305]
+    steps:
+      - ...
 
-- job: some_cw310_job
-  pool:
-    name: FPGA SCA
-    demands: BOARD -equals cw310
-  steps:
-    - ...
+  some_cw310_job:
+    runs-on: [ubuntu-22.04-fpga, cw310]
+    steps:
+      - ...
 ```
 
 ## Approving external CI runs
@@ -36,10 +33,8 @@ The CI pipelines run on systems managed by lowRISC. To prevent external GitHub
 users from running arbitrary code on our systems, CI will not run on pull
 requests from forks of users outside the [lowRISC GitHub organisation].
 
-Members of the lowRISC GitHub organisation can manually allow a pull request to
-run in CI by [adding a comment][Azure comment triggers]:
+GitHub users with write access to the repository can allow a pull request to run
+in CI using the GitHub UI. A button should appear next to the list of checks
+that will be run.
 
-> /AzurePipelines run
-
-[Azure comment triggers]: https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers
 [lowRISC GitHub organisation]: https://github.com/lowrisc/


### PR DESCRIPTION
This PR adds a GitHub Actions workflow which performs the same tasks as the Azure pipeline that runs FPGA jobs.

This work is part of a move from Azure to GitHub Actions generally in OpenTitan.

I'm planning to leave the `ci/azure-pipelines.yml` file here for a short while in case we have any issues with the GitHub Actions workflow so that we can switch back easier. Once we know it's working well we can remove that configuration.