### PR TITLE
[scope] Configure WaveRunner from config file

### DIFF
--- a/capture/capture_aes.py
+++ b/capture/capture_aes.py
@@ -137,6 +137,9 @@ def setup(cfg: dict, project: Path):
         sparsing = cfg[scope_type].get("sparsing"),
         scope_gain = cfg[scope_type].get("scope_gain"),
         pll_frequency = cfg["target"]["pll_frequency"],
+        channel_configs = cfg[scope_type].get("channel_configs"),
+        trigger_config = cfg[scope_type].get("trigger_config"),
+        timebase_config = cfg[scope_type].get("timebase_config")
     )
     scope = Scope(scope_cfg)
 

--- a/capture/capture_kmac.py
+++ b/capture/capture_kmac.py
@@ -141,6 +141,9 @@ def setup(cfg: dict, project: Path):
         sparsing = cfg[scope_type].get("sparsing"),
         scope_gain = cfg[scope_type].get("scope_gain"),
         pll_frequency = cfg["target"]["pll_frequency"],
+        channel_configs = cfg[scope_type].get("channel_configs"),
+        trigger_config = cfg[scope_type].get("trigger_config"),
+        timebase_config = cfg[scope_type].get("timebase_config")
     )
     scope = Scope(scope_cfg)
 

--- a/capture/capture_otbn.py
+++ b/capture/capture_otbn.py
@@ -139,18 +139,21 @@ def setup(cfg: dict, project: Path):
 
     # Create scope config & setup scope.
     scope_cfg = ScopeConfig(
-        scope_type=scope_type,
+        scope_type = scope_type,
         batch_mode = batch,
         bit = cfg[scope_type].get("bit"),
-        acqu_channel=cfg[scope_type].get("channel"),
-        ip=cfg[scope_type].get("waverunner_ip"),
-        num_samples=cfg[scope_type]["num_samples"],
-        offset_samples=cfg[scope_type]["offset_samples"],
-        sampling_rate=cfg[scope_type].get("sampling_rate"),
-        num_segments=cfg[scope_type]["num_segments"],
-        sparsing=cfg[scope_type].get("sparsing"),
-        scope_gain=cfg[scope_type].get("scope_gain"),
-        pll_frequency=cfg["target"]["pll_frequency"],
+        acqu_channel = cfg[scope_type].get("channel"),
+        ip = cfg[scope_type].get("waverunner_ip"),
+        num_samples = cfg[scope_type]["num_samples"],
+        offset_samples = cfg[scope_type]["offset_samples"],
+        sampling_rate = cfg[scope_type].get("sampling_rate"),
+        num_segments = cfg[scope_type].get("num_segments"),
+        sparsing = cfg[scope_type].get("sparsing"),
+        scope_gain = cfg[scope_type].get("scope_gain"),
+        pll_frequency = cfg["target"]["pll_frequency"],
+        channel_configs = cfg[scope_type].get("channel_configs"),
+        trigger_config = cfg[scope_type].get("trigger_config"),
+        timebase_config = cfg[scope_type].get("timebase_config")
     )
     scope = Scope(scope_cfg)
 

--- a/capture/capture_sha3.py
+++ b/capture/capture_sha3.py
@@ -126,6 +126,9 @@ def setup(cfg: dict, project: Path):
         sparsing = cfg[scope_type].get("sparsing"),
         scope_gain = cfg[scope_type].get("scope_gain"),
         pll_frequency = cfg["target"]["pll_frequency"],
+        channel_configs = cfg[scope_type].get("channel_configs"),
+        trigger_config = cfg[scope_type].get("trigger_config"),
+        timebase_config = cfg[scope_type].get("timebase_config")
     )
     scope = Scope(scope_cfg)
 

--- a/capture/scopes/scope.py
+++ b/capture/scopes/scope.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from scopes.chipwhisperer.husky import Husky
-from scopes.waverunner.waverunner import WaveRunner
+from scopes.waverunner.waverunner import Channel, Timebase, Trigger, WaveRunner
 
 
 @dataclass
@@ -28,6 +28,9 @@ class ScopeConfig:
     scope_gain: Optional[float] = 1
     pll_frequency: Optional[int] = 1
     sampling_rate: Optional[int] = 0
+    channel_configs: Optional[list] = None
+    trigger_config: Optional[str] = None
+    timebase_config: Optional[str] = None
 
 
 class Scope:
@@ -90,6 +93,25 @@ class Scope:
                     first_point = self.scope_cfg.offset_samples,
                     acqu_channel = self.scope_cfg.acqu_channel
                 )
+                # If a user defined config is provided, configure the channel,
+                # timebase, and the trigger.
+                if self.scope_cfg.channel_configs is not None:
+                    for channel_config in self.scope_cfg.channel_configs:
+                        scope.configure_channel(
+                            Channel(name = channel_config["name"],
+                                    trace_enable = channel_config["trace_enable"],
+                                    vdiv = channel_config["vdiv"],
+                                    offset = channel_config["offset"]))
+                if self.scope_cfg.timebase_config is not None:
+                    scope.configure_timebase(
+                        Timebase(tdiv = self.scope_cfg.timebase_config["tdiv"],
+                                 delay = self.scope_cfg.timebase_config["delay"]))
+                if self.scope_cfg.trigger_config is not None:
+                    scope.configure_trigger(
+                        Trigger(channel = self.scope_cfg.trigger_config["channel"],
+                                edge = self.scope_cfg.trigger_config["edge"],
+                                coupling = self.scope_cfg.trigger_config["coupling"],
+                                level = self.scope_cfg.trigger_config["level"]))
                 return scope
             else:
                 raise RuntimeError("Error: No WaveRunner IP provided!")


### PR DESCRIPTION
This commit allows the user to configure the channels, timebase, and the trigger for a WaveRunner scope using the configuration files.

When providing the config, the scope gets automatically configured allowing for reproducible capture runs.