### PR TITLE
[fi] Command handlers for Ibex tests

### DIFF
--- a/fault_injection/configs/pen.global_fi.ibex.char.conditional_branch.cw310.yaml
+++ b/fault_injection/configs/pen.global_fi.ibex.char.conditional_branch.cw310.yaml
@@ -1,0 +1,39 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM4"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  parameter_generation: "random"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 100
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 10
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "ibex_char_conditional_branch"
+  expected_result: '{"result1":10001,"result2":0,"err_status":0}'

--- a/fault_injection/configs/pen.global_fi.ibex.char.flash_read.cw310.yaml
+++ b/fault_injection/configs/pen.global_fi.ibex.char.flash_read.cw310.yaml
@@ -1,0 +1,39 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM4"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  parameter_generation: "random"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 100
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 10
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "ibex_char_flash_read"
+  expected_result: '{"result":0,"err_status":0}'

--- a/fault_injection/configs/pen.global_fi.ibex.char.flash_write.cw310.yaml
+++ b/fault_injection/configs/pen.global_fi.ibex.char.flash_write.cw310.yaml
@@ -1,0 +1,39 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM4"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  parameter_generation: "random"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 100
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 10
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "ibex_char_flash_write"
+  expected_result: '{"result":0,"err_status":0}'

--- a/fault_injection/configs/pen.global_fi.ibex.char.sram_read.cw310.yaml
+++ b/fault_injection/configs/pen.global_fi.ibex.char.sram_read.cw310.yaml
@@ -1,0 +1,39 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM4"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  parameter_generation: "random"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 100
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 10
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "ibex_char_sram_read"
+  expected_result: '{"result":0,"err_status":0}'

--- a/fault_injection/configs/pen.global_fi.ibex.char.sram_write.cw310.yaml
+++ b/fault_injection/configs/pen.global_fi.ibex.char.sram_write.cw310.yaml
@@ -1,0 +1,39 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM4"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  parameter_generation: "random"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 100
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 10
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "ibex_char_sram_write"
+  expected_result: '{"result":0,"err_status":0}'

--- a/fault_injection/configs/pen.global_fi.ibex.char.unconditional_branch.cw310.yaml
+++ b/fault_injection/configs/pen.global_fi.ibex.char.unconditional_branch.cw310.yaml
@@ -1,0 +1,39 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM4"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  parameter_generation: "random"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 100
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 10
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "ibex_char_unconditional_branch"
+  expected_result: '{"result":100,"err_status":0}'

--- a/objs/sca_ujson_fpga_cw310.bin
+++ b/objs/sca_ujson_fpga_cw310.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ad1df47ebaad117676b11d7b3937f5e3b6becf9c73914554badd4e32ba73052
-size 298684
+oid sha256:b79fa7125b748b00bc231ecb563e266edf4213eb27ef2318b35315d5c32169b1
+size 304188

--- a/target/communication/fi_ibex_commands.py
+++ b/target/communication/fi_ibex_commands.py
@@ -54,6 +54,60 @@ class OTFIIbex:
         time.sleep(0.01)
         self.target.write(json.dumps("CharMemOpLoop").encode("ascii"))
 
+    def ibex_char_flash_read(self) -> None:
+        """ Starts the ibex.char.flash_read test.
+        """
+        # IbexFi command.
+        self._ujson_ibex_fi_cmd()
+        # CharFlashRead command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("CharFlashRead").encode("ascii"))
+
+    def ibex_char_flash_write(self) -> None:
+        """ Starts the ibex.char.flash_write test.
+        """
+        # IbexFi command.
+        self._ujson_ibex_fi_cmd()
+        # CharFlashWrite command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("CharFlashWrite").encode("ascii"))
+
+    def ibex_char_sram_read(self) -> None:
+        """ Starts the ibex.char.sram_read test.
+        """
+        # IbexFi command.
+        self._ujson_ibex_fi_cmd()
+        # CharSramRead command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("CharSramRead").encode("ascii"))
+
+    def ibex_char_sram_write(self) -> None:
+        """ Starts the ibex.char.sram_write test.
+        """
+        # IbexFi command.
+        self._ujson_ibex_fi_cmd()
+        # CharSramWrite command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("CharSramWrite").encode("ascii"))
+
+    def ibex_char_unconditional_branch(self) -> None:
+        """ Starts the ibex.char.unconditional_branch test.
+        """
+        # IbexFi command.
+        self._ujson_ibex_fi_cmd()
+        # CharUncondBranch command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("CharUncondBranch").encode("ascii"))
+
+    def ibex_char_conditional_branch(self) -> None:
+        """ Starts the ibex.char.conditional_branch test.
+        """
+        # IbexFi command.
+        self._ujson_ibex_fi_cmd()
+        # CharCondBranch command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("CharCondBranch").encode("ascii"))
+
     def init_trigger(self) -> None:
         """ Initialize the FI trigger on the chip.
 


### PR DESCRIPTION
This commit adds the command handlers and configs for the following Ibex FI penetration tests:
- ibex.char.flash_read
- ibex.char.flash_write
- ibex.char.sram_read
- ibex.char.sram_write
- ibex.char.unconditional_branch
- ibex.char.conditional_branch

The device code is located in lowRISC/opentitan#22135 and the binary was compiled from this PR using:
./bazelisk.sh build //sw/device/tests/crypto/cryptotest/firmware:firmware_fpga_cw310_test_rom