### PR TITLE
[fi] Add support for multiple Huskies

### DIFF
--- a/fault_injection/fi_gear/fi_gear.py
+++ b/fault_injection/fi_gear/fi_gear.py
@@ -84,6 +84,7 @@ class FIGear:
         elif self.gear_type == "husky" and self.fi_type == "voltage_glitch":
             self.gear = HuskyVCC(
                 pll_frequency = cfg["target"]["pll_frequency"],
+                serial_number = cfg["fisetup"].get("fi_gear_sn"),
                 glitch_width_min = cfg["fisetup"]["glitch_width_min"],
                 glitch_width_max = cfg["fisetup"]["glitch_width_max"],
                 glitch_width_step = cfg["fisetup"]["glitch_width_step"],

--- a/fault_injection/fi_gear/husky/husky_vcc.py
+++ b/fault_injection/fi_gear/husky/husky_vcc.py
@@ -15,7 +15,8 @@ class HuskyVCC:
     """ Initialize Husky for VCC glitching.
 
     Args:
-        pll_frequency. The PLL frequency of the target.
+        pll_frequency: The PLL frequency of the target.
+        serial_number: The SN of the Husky.
         glitch_width_min: Lower bound for the glitch width.
         glitch_width_max: Upper bound for the glitch width.
         glitch_width_step: Step for the glitch width.
@@ -23,14 +24,15 @@ class HuskyVCC:
         trigger_delay_max: Upper bound for the trigger delay.
         trigger_step: Step for the trigger delay.
     """
-    def __init__(self, pll_frequency: int, glitch_width_min: float,
-                 glitch_width_max: float, glitch_width_step: float,
-                 trigger_delay_min: int, trigger_delay_max: int,
-                 trigger_step: int, num_iterations: int,
+    def __init__(self, pll_frequency: int, serial_number: str,
+                 glitch_width_min: float, glitch_width_max: float,
+                 glitch_width_step: float, trigger_delay_min: int,
+                 trigger_delay_max: int, trigger_step: int, num_iterations: int,
                  parameter_generation: str):
         # Set Husky parameters.
         self.scope = None
         self.pll_frequency = pll_frequency
+        self.sn = serial_number
 
         # Set glitch parameter space.
         self.glitch_width_min = glitch_width_min
@@ -57,8 +59,12 @@ class HuskyVCC:
         Configure Husky crowbar in such a way that the glitcher uses the HP
         MOSFET and a single glitch is clkgen_freq long.
         """
-        check_version.check_husky("1.5.0")
-        self.scope = cw.scope()
+        if self.sn is not None:
+            check_version.check_husky("1.5.0", sn=str(self.sn))
+            self.scope = cw.scope(sn=str(self.sn))
+        else:
+            check_version.check_husky("1.5.0")
+            self.scope = cw.scope()
 
         if not self.scope._is_husky:
             raise RuntimeError("Only ChipWhisperer Husky is supported!")

--- a/util/check_version.py
+++ b/util/check_version.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Optional
+
 import chipwhisperer as cw
 
 
@@ -21,7 +23,7 @@ def check_cw(cw_version_exp: str) -> None:
         raise RuntimeError(f"Please update the Python requirements. CW version: {cw_version}, expected CW version: {cw_version_exp}")  # noqa: E501
 
 
-def check_husky(husky_fw_exp: str) -> None:
+def check_husky(husky_fw_exp: str, sn: Optional[str] = None) -> None:
     """ Check ChipWhisperer Husky firmware version.
 
     Read CW Husky FW version and compare against expected version.
@@ -32,6 +34,9 @@ def check_husky(husky_fw_exp: str) -> None:
     Returns:
         Raises a runtime error on a mismatch.
     """
-    husky_fw = cw.scope().fw_version_str
+    if sn is not None:
+        husky_fw = cw.scope(sn=str(sn)).fw_version_str
+    else:
+        husky_fw = cw.scope().fw_version_str
     if husky_fw != husky_fw_exp:
         raise RuntimeError(f"Please update the Husky firmware. FW version: {husky_fw}, expected FW version: {husky_fw_exp}")  # noqa: E501


### PR DESCRIPTION
This commit enables us to run multiple FI setups using different Huskies. For this, the serial number can be specified with the fisetup.fi_gear_sn parameter in the config.