### PR TITLE
[fi] Add SRAM static cmd handler

### DIFF
--- a/fault_injection/configs/pen.global_fi.ibex.char.sram_static.cw310.yaml
+++ b/fault_injection/configs/pen.global_fi.ibex.char.sram_static.cw310.yaml
@@ -1,0 +1,39 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM4"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  parameter_generation: "random"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 100
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 10
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "ibex_char_sram_write"
+  expected_result: '{"err_status":0,"addresses":[0,0,0,0,0,0,0,0]}'

--- a/target/communication/fi_ibex_commands.py
+++ b/target/communication/fi_ibex_commands.py
@@ -90,6 +90,15 @@ class OTFIIbex:
         time.sleep(0.01)
         self.target.write(json.dumps("CharSramWrite").encode("ascii"))
 
+    def ibex_char_sram_static(self) -> None:
+        """ Starts the ibex.char.sram_static test.
+        """
+        # IbexFi command.
+        self._ujson_ibex_fi_cmd()
+        # CharSramWrite command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("CharSramStatic").encode("ascii"))
+
     def ibex_char_unconditional_branch(self) -> None:
         """ Starts the ibex.char.unconditional_branch test.
         """


### PR DESCRIPTION
This commit adds the command handler for the
ibex_char_sram_write test. The device PR is located in lowRISC/opentitan#22272