### PR TITLE
Update opentitantool

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,4 @@
 *.npy filter=lfs diff=lfs merge=lfs -text
 test/data/tvla_general/* filter=lfs diff=lfs merge=lfs -text
 ci/ci_trace_check/golden_traces/* filter=lfs diff=lfs merge=lfs -text
-target/lib/opentitantool filter=lfs diff=lfs merge=lfs -text
+objs/opentitantool filter=lfs diff=lfs merge=lfs -text

--- a/target/lib/opentitantool
+++ b/target/lib/opentitantool
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30f91a479b17cdaac0fc8c00a16af1634a85cffc3fbe851f3fe0c5e03b6e451c
-size 36033424

--- a/target/targets.py
+++ b/target/targets.py
@@ -59,7 +59,7 @@ class Target:
             )
         elif self.target_cfg.target_type == "chip":
             target = Chip(firmware = self.target_cfg.fw_bin,
-                          opentitantool_path = "../target/lib/opentitantool",
+                          opentitantool_path = "../objs/opentitantool",
                           usb_serial=self.target_cfg.usb_serial)
         else:
             raise RuntimeError("Error: Target not supported!")


### PR DESCRIPTION
This commit updates the opentitantool to the version from lowRISC/opentitan@28afcfc as the version previously used in ot-sca is quite outdated.

Moreover, this commit deletes the redundant opentitantool located in target/lib that accidentally got merged into this repo.