### PR TITLE
Re-establish com interface after reset

### DIFF
--- a/target/targets.py
+++ b/target/targets.py
@@ -87,7 +87,7 @@ class Target:
         """Resets the target. """
         self.target.reset_target()
         if com_reset and self.target_cfg.protocol == "ujson":
-            self._init_communication()
+            self.com_interface = self._init_communication()
 
     def write(self, data, cmd: Optional[str] = ""):
         """Write data to the target. """


### PR DESCRIPTION
This commit fixes the re-init of the COM interface after a reset was issued by the attack script.