### PR TITLE
[tvla] Optimize memory utilization

### DIFF
--- a/analysis/tvla.py
+++ b/analysis/tvla.py
@@ -573,12 +573,7 @@ def run_tvla(ctx: typer.Context):
                     # arrays. For compatiblity, we need to convert everything to numpy arrays.
                     # Eventually, we can drop this.
                     if i_step == 0:
-                        if OTTraceLib:
-                            if general_test_data:
-                                plaintexts_nparrays = project.get_plaintexts()
-                            else:
-                                keys_nparrays = project.get_keys()
-                        else:
+                        if not OTTraceLib:
                             # Convert all keys from the project file to numpy
                             # arrays once.
                             keys_nparrays = []
@@ -590,12 +585,17 @@ def run_tvla(ctx: typer.Context):
                                 else:
                                     keys_nparrays.append(np.frombuffer(project.project.keys[i],
                                                                        dtype=np.uint8))
-
                     # Select the correct slice of keys for each step.
-                    if general_test_data:
-                        plaintexts[:] = plaintexts_nparrays[trace_start:trace_end + 1]
+                    if OTTraceLib:
+                        if general_test_data:
+                            plaintexts[:] = project.get_plaintexts(trace_start, trace_end + 1)
+                        else:
+                            keys[:] = project.get_keys(trace_start, trace_end + 1)
                     else:
-                        keys[:] = keys_nparrays[trace_start:trace_end + 1]
+                        if general_test_data:
+                            plaintexts[:] = plaintexts_nparrays[trace_start:trace_end + 1]
+                        else:
+                            keys[:] = keys_nparrays[trace_start:trace_end + 1]
 
                 # Only select traces to use.
                 if general_test_key:


### PR DESCRIPTION
Previously, in i_step=0, the TVLA script opened all plaintext or keys at once. This is problematic, as for large datasets and large keys/ptx the memory consumption is tremendous.

This commit optimizes memory utilization by just opening the keys/ptx that correspond to the current step.