### PR TITLE
[sca] Add KeySideloadFvsr and EcdsaP256 OTBN tests

### DIFF
--- a/capture/capture_otbn.py
+++ b/capture/capture_otbn.py
@@ -21,7 +21,7 @@ from scopes.scope import (Scope, ScopeConfig, convert_num_cycles,
 from tqdm import tqdm
 
 import util.helpers as helpers
-from target.communication.sca_otbn_commands import OTOTBNVERT
+from target.communication.sca_otbn_commands import OTOTBN
 from target.communication.sca_trigger_commands import OTTRIGGER
 from target.targets import Target, TargetConfig
 from util import check_version
@@ -197,7 +197,7 @@ def establish_communication(target, capture_cfg: CaptureConfig):
         ot_trig: The communication interface to the SCA trigger.
     """
     # Create communication interface to OTBN.
-    ot_otbn_vert = OTOTBNVERT(target=target, protocol=capture_cfg.protocol)
+    ot_otbn_vert = OTOTBN(target=target, protocol=capture_cfg.protocol)
 
     # Create communication interface to SCA trigger.
     ot_trig = OTTRIGGER(target=target, protocol=capture_cfg.protocol)
@@ -206,7 +206,7 @@ def establish_communication(target, capture_cfg: CaptureConfig):
 
 
 def configure_cipher(cfg: dict, target, capture_cfg: CaptureConfig,
-                     ot_otbn_vert) -> OTOTBNVERT:
+                     ot_otbn_vert) -> OTOTBN:
     """ Configure the OTBN app.
 
     Establish communication with the OTBN keygen app and configure the seed.
@@ -458,7 +458,7 @@ def generate_ref_crypto_modinv(cfg: dict, sample_fixed, curve_cfg: CurveConfig,
     return k_used, input_k0_used, input_k1_used, expected_output, sample_fixed
 
 
-def check_ciphertext_keygen(ot_otbn_vert: OTOTBNVERT, expected_key,
+def check_ciphertext_keygen(ot_otbn_vert: OTOTBN, expected_key,
                             curve_cfg: CurveConfig):
     """ Compares the received with the generated key.
 
@@ -495,7 +495,7 @@ def check_ciphertext_keygen(ot_otbn_vert: OTOTBNVERT, expected_key,
     return share0, share1
 
 
-def check_ciphertext_modinv(ot_otbn_vert: OTOTBNVERT, expected_output,
+def check_ciphertext_modinv(ot_otbn_vert: OTOTBN, expected_output,
                             curve_cfg: CurveConfig):
     """ Compares the received modular inverse output with the generated output.
 
@@ -527,7 +527,7 @@ def check_ciphertext_modinv(ot_otbn_vert: OTOTBNVERT, expected_output,
     return actual_output
 
 
-def capture_keygen(cfg: dict, scope: Scope, ot_otbn_vert: OTOTBNVERT,
+def capture_keygen(cfg: dict, scope: Scope, ot_otbn_vert: OTOTBN,
                    capture_cfg: CaptureConfig, curve_cfg: CurveConfig,
                    project: SCAProject, target: Target):
     """ Capture power consumption during selected OTBN operation.
@@ -605,7 +605,7 @@ def capture_keygen(cfg: dict, scope: Scope, ot_otbn_vert: OTOTBNVERT,
             pbar.update(capture_cfg.num_segments)
 
 
-def capture_modinv(cfg: dict, scope: Scope, ot_otbn_vert: OTOTBNVERT,
+def capture_modinv(cfg: dict, scope: Scope, ot_otbn_vert: OTOTBN,
                    capture_cfg: CaptureConfig, curve_cfg: CurveConfig,
                    project: SCAProject, target: Target):
     """ Capture power consumption during selected OTBN operation.

--- a/target/communication/sca_otbn_commands.py
+++ b/target/communication/sca_otbn_commands.py
@@ -1,19 +1,152 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-"""Communication interface for the SHA3 SCA application on OpenTitan.
+"""Communication interface for the OTBN SCA application on OpenTitan.
 
 Communication with OpenTitan either happens over simpleserial or the uJson
 command interface.
 """
+import json
+import time
+from typing import Optional
 
 
-class OTOTBNVERT:
+class OTOTBN:
     def __init__(self, target, protocol: str) -> None:
         self.target = target
         self.simple_serial = True
         if protocol == "ujson":
             self.simple_serial = False
+
+    def _ujson_otbn_sca_cmd(self):
+        # TODO: without the delay, the device uJSON command handler program
+        # does not recognize the commands. Tracked in issue #256.
+        time.sleep(0.01)
+        self.target.write(json.dumps("OtbnSca").encode("ascii"))
+
+    def init(self, icache_disable: bool, dummy_instr_disable: bool):
+        """ Initializes OTBN on the target.
+        Args:
+            icache_disable: If true, disable the iCache. If false, use default config
+                            set in ROM.
+            dummy_instr_disable: If true, disable the dummy instructions. If false,
+                                 use default config set in ROM.
+        Returns:
+            The device ID of the device.
+        """
+        if not self.simple_serial:
+            # OtbnSca command.
+            self._ujson_otbn_sca_cmd()
+            # Init the OTBN core.
+            self.target.write(json.dumps("Init").encode("ascii"))
+            # Disable iCache / dummy instructions.
+            time.sleep(0.01)
+            data = {"icache_disable": icache_disable, "dummy_instr_disable": dummy_instr_disable}
+            self.target.write(json.dumps(data).encode("ascii"))
+            # Read back device ID from device.
+            return self.read_response(max_tries=30)
+
+    def init_keymgr(self):
+        """ Initializes the key manager for OTBN on the target.
+        """
+        if not self.simple_serial:
+            # OtbnSca command.
+            self._ujson_otbn_sca_cmd()
+            # Init the key manager.
+            self.target.write(json.dumps("InitKeyMgr").encode("ascii"))
+
+    def key_sideload_fvsr(self, seed: int):
+        """ Starts the key sidloading FvsR test on OTBN.
+        Args:
+            seed: The fixed seed used by the key manager.
+        """
+        if not self.simple_serial:
+            # OtbnSca command.
+            self._ujson_otbn_sca_cmd()
+            # Start the KeySideloadFvsr test.
+            self.target.write(json.dumps("KeySideloadFvsr").encode("ascii"))
+            time.sleep(0.01)
+            seed_data = {"fixed_seed": seed}
+            self.target.write(json.dumps(seed_data).encode("ascii"))
+
+    def ecdsa_p256_sign(self, masking_on: bool, msg, d0, k0):
+        """ Starts the EcdsaP256Sign test on OTBN.
+        Args:
+            masking_on: Turn on/off masking.
+            msg: Message array (8xuint32_t)
+            d0: Message array (10xuint32_t)
+            k0: Message array (10xuint32_t)
+        """
+        if not self.simple_serial:
+            # OtbnSca command.
+            self._ujson_otbn_sca_cmd()
+            # Start the EcdsaP256Sign test.
+            self.target.write(json.dumps("EcdsaP256Sign").encode("ascii"))
+            time.sleep(0.01)
+            # Configure masking.
+            masks = {"en_masks": masking_on}
+            self.target.write(json.dumps(masks).encode("ascii"))
+            time.sleep(0.01)
+            # Send msg, d0, and k0.
+            data = {"msg": msg, "d0": d0, "ko": k0}
+            self.target.write(json.dumps(data).encode("ascii"))
+            time.sleep(0.01)
+
+    def ecdsa_p256_sign_batch(self, num_traces: int, masking_on: bool, msg, d0, k0):
+        """ Starts the EcdsaP256SignBatch test on OTBN.
+        Args:
+            num_traces: Number of batch operations.
+            masking_on: Turn on/off masking.
+            msg: Message array (8xuint32_t)
+            d0: Message array (10xuint32_t)
+            k0: Message array (10xuint32_t)
+        """
+        if not self.simple_serial:
+            # OtbnSca command.
+            self._ujson_otbn_sca_cmd()
+            # Start the EcdsaP256SignBatch test.
+            self.target.write(json.dumps("EcdsaP256Sign").encode("ascii"))
+            time.sleep(0.01)
+            # Configure number of traces.
+            num_traces = {"num_traces": num_traces}
+            self.target.write(json.dumps(num_traces).encode("ascii"))
+            time.sleep(0.01)
+            # Configure masking.
+            masks = {"en_masks": masking_on}
+            self.target.write(json.dumps(masks).encode("ascii"))
+            time.sleep(0.01)
+            # Send msg, d0, and k0.
+            data = {"msg": msg, "d0": d0, "ko": k0}
+            self.target.write(json.dumps(data).encode("ascii"))
+            time.sleep(0.01)
+
+    def ecdsa_p256_sign_batch_fvsr(self, num_traces: int, masking_on: bool, msg, d0, k0):
+        """ Starts the EcdsaP256SignFvsrBatch test on OTBN.
+        Args:
+            num_traces: Number of batch operations.
+            masking_on: Turn on/off masking.
+            msg: Message array (8xuint32_t)
+            d0: Message array (10xuint32_t)
+            k0: Message array (10xuint32_t)
+        """
+        if not self.simple_serial:
+            # OtbnSca command.
+            self._ujson_otbn_sca_cmd()
+            # Start the EcdsaP256SignBatch test.
+            self.target.write(json.dumps("EcdsaP256SignFvsrBatch").encode("ascii"))
+            time.sleep(0.01)
+            # Configure number of traces.
+            num_traces = {"num_traces": num_traces}
+            self.target.write(json.dumps(num_traces).encode("ascii"))
+            time.sleep(0.01)
+            # Configure masking.
+            masks = {"en_masks": masking_on}
+            self.target.write(json.dumps(masks).encode("ascii"))
+            time.sleep(0.01)
+            # Send msg, d0, and k0.
+            data = {"msg": msg, "d0": d0, "ko": k0}
+            self.target.write(json.dumps(data).encode("ascii"))
+            time.sleep(0.01)
 
     def choose_otbn_app(self, app):
         """ Select the OTBN application.
@@ -105,3 +238,19 @@ class OTOTBNVERT:
         """
         if self.simple_serial:
             return self.target.read("r", len_bytes, ack=False)
+
+    def read_response(self, max_tries: Optional[int] = 1) -> str:
+        """ Read response from OTBN SCA framework.
+        Args:
+            max_tries: Maximum number of attempts to read from UART.
+
+        Returns:
+            The JSON response of OpenTitan.
+        """
+        it = 0
+        while it != max_tries:
+            read_line = str(self.target.readline())
+            if "RESP_OK" in read_line:
+                return read_line.split("RESP_OK:")[1].split(" CRC:")[0]
+            it += 1
+        return ""


### PR DESCRIPTION
This commit adds the following OTBN SCA routines to the code base:
- init: Init the OTBN SCA test on the device
- init_keymgr: Prepare the keymanager for the OTBN key sideloading test
- key_sideload_fvsr: Start the test
- read_response: Read response from device
- ecdsa_p256_sign: Test available in single, batch, and FvsR mode

Please note that this commit only adds these tests to the communication
stack but not to the capture script.