### PR TITLE
[fi] Add additional hardened check cmd handlers

### DIFF
--- a/fault_injection/configs/pen.global_fi.ibex.char.hardened_check_eq_unimps.cw310.yaml
+++ b/fault_injection/configs/pen.global_fi.ibex.char.hardened_check_eq_unimps.cw310.yaml
@@ -34,7 +34,9 @@ fiproject:
   plot_y_axis: "glitch_width"
   plot_y_axis_legend: "[cycles]"
 test:
-  which_test: "ibex_char_hardened_check_eq_unimps"
+  which_test: "ibex_char_hardened_check_eq_unimp"
+  # which_test: "ibex_char_hardened_check_eq_2_unimps"
+  # which_test: "ibex_char_hardened_check_eq_3_unimps"
   # For this test, the expected result is actually a crash of the system. On
   # a successful FI attack, this could be one result:
   expected_result: '{"result1":0,"result2":1,"err_status":0,"alerts":0}'

--- a/target/communication/fi_ibex_commands.py
+++ b/target/communication/fi_ibex_commands.py
@@ -268,14 +268,32 @@ class OTFIIbex:
         time.sleep(0.01)
         self.target.write(json.dumps("AddressTranslation").encode("ascii"))
 
-    def ibex_char_hardened_check_eq_unimps(self) -> None:
-        """ Starts the ibex.fi.char.hardened_check_eq_unimps test.
+    def ibex_char_hardened_check_eq_unimp(self) -> None:
+        """ Starts the ibex.fi.char.hardened_check_eq_unimp test.
         """
         # IbexFi command.
         self._ujson_ibex_fi_cmd()
-        # CharHardenedCheck command.
+        # CharHardenedCheckUnimp command.
         time.sleep(0.01)
-        self.target.write(json.dumps("CharHardenedCheck").encode("ascii"))
+        self.target.write(json.dumps("CharHardenedCheckUnimp").encode("ascii"))
+
+    def ibex_char_hardened_check_eq_2_unimps(self) -> None:
+        """ Starts the ibex.fi.char.hardened_check_eq_2_unimps test.
+        """
+        # IbexFi command.
+        self._ujson_ibex_fi_cmd()
+        # CharHardenedCheck2Unimps command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("CharHardenedCheck2Unimps").encode("ascii"))
+
+    def ibex_char_hardened_check_eq_3_unimps(self) -> None:
+        """ Starts the ibex.fi.char.hardened_check_eq_3_unimps test.
+        """
+        # IbexFi command.
+        self._ujson_ibex_fi_cmd()
+        # CharHardenedCheck3Unimps command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("CharHardenedCheck3Unimps").encode("ascii"))
 
     def read_response(self, max_tries: Optional[int] = 1) -> str:
         """ Read response from Ibex FI framework.


### PR DESCRIPTION
This commit adds the following FI test command handlers:
- ibex_char_hardened_check_eq_unimp
- ibex_char_hardened_check_eq_2_unimps
- ibex_char_hardened_check_eq_3_unimps