### PR TITLE
[fi] Add new OTBN tests and enable transmitting payload

### DIFF
--- a/fault_injection/configs/pen.global_fi.otbn.char.bn.rshi.cw310.yaml
+++ b/fault_injection/configs/pen.global_fi.otbn.char.bn.rshi.cw310.yaml
@@ -1,0 +1,44 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM1"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 10000
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 100
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "otbn_char_bn_rshi"
+  expected_result: '{"big_num":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"insn_cnt":109,"err_otbn":0,"err_ibx":0,"alerts":[0,0,0]}'
+  input: {"big_num": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+  # Set to true if the test should ignore alerts returned by the test. As the
+  # alert handler on the device could sometime fire alerts that are not
+  # related to the FI, ignoring is by default set to true. A manual analysis
+  # still can be performed as the alerts are stored in the database.
+  ignore_alerts: True

--- a/fault_injection/configs/pen.global_fi.otbn.char.bn.sel.cw310.yaml
+++ b/fault_injection/configs/pen.global_fi.otbn.char.bn.sel.cw310.yaml
@@ -1,0 +1,44 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM1"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 10000
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 100
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "otbn_char_bn_sel"
+  expected_result: '{"big_num":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"insn_cnt":1014,"err_otbn":0,"err_ibx":0,"alerts":[0,0,0]}'
+  input: {"big_num": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+  # Set to true if the test should ignore alerts returned by the test. As the
+  # alert handler on the device could sometime fire alerts that are not
+  # related to the FI, ignoring is by default set to true. A manual analysis
+  # still can be performed as the alerts are stored in the database.
+  ignore_alerts: True

--- a/fault_injection/configs/pen.global_fi.otbn.char.mem.cw310.yaml
+++ b/fault_injection/configs/pen.global_fi.otbn.char.mem.cw310.yaml
@@ -1,0 +1,44 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM1"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 10000
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 100
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "otbn_char_mem"
+  expected_result: '{"res":0,"imem_data":[0,0,0,0,0,0,0,0],"imem_addr":[0,0,0,0,0,0,0,0],"dmem_data":[0,0,0,0,0,0,0,0],"dmem_addr":[0,0,0,0,0,0,0,0],"err_otbn":0,"err_ibx":0,"alerts":[0,0,0]}'
+  config: {"byte_offset": 0, "num_words": 4, "imem": False, "dmem": True}
+  # Set to true if the test should ignore alerts returned by the test. As the
+  # alert handler on the device could sometime fire alerts that are not
+  # related to the FI, ignoring is by default set to true. A manual analysis
+  # still can be performed as the alerts are stored in the database.
+  ignore_alerts: True

--- a/fault_injection/configs/pen.global_fi.otbn.pc.cw310.yaml
+++ b/fault_injection/configs/pen.global_fi.otbn.pc.cw310.yaml
@@ -1,0 +1,44 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/sca_ujson_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM1"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 10000
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 100
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "otbn_pc"
+  expected_result: '{"pc_dmem":2224,"pc_otbn":2224,"insn_cnt":472,"err_otbn":0,"err_ibx":0,"alerts":[0,0,0]}'
+  input: {"pc": 0x8b0}
+  # Set to true if the test should ignore alerts returned by the test. As the
+  # alert handler on the device could sometime fire alerts that are not
+  # related to the FI, ignoring is by default set to true. A manual analysis
+  # still can be performed as the alerts are stored in the database.
+  ignore_alerts: True

--- a/target/communication/fi_otbn_commands.py
+++ b/target/communication/fi_otbn_commands.py
@@ -174,6 +174,14 @@ class OTFIOtbn:
         test_function = getattr(self, cfg["test"]["which_test"])
         test_function()
 
+    def write_payload(self, payload: dict) -> None:
+        """ Send test payload to OpenTitan.
+        Args:
+            payload: The data to send to the target.
+        """
+        time.sleep(0.01)
+        self.target.write(json.dumps(payload).encode("ascii"))
+
     def read_response(self, max_tries: Optional[int] = 1) -> str:
         """ Read response from Otbn FI framework.
         Args:

--- a/target/communication/fi_otbn_commands.py
+++ b/target/communication/fi_otbn_commands.py
@@ -63,6 +63,33 @@ class OTFIOtbn:
         time.sleep(0.01)
         self.target.write(json.dumps("CharJal").encode("ascii"))
 
+    def otbn_char_mem(self) -> None:
+        """ Starts the otbn.fi.char.mem test.
+        """
+        # OtbnFi command.
+        self._ujson_otbn_fi_cmd()
+        # CharMem command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("CharMem").encode("ascii"))
+
+    def otbn_char_bn_sel(self) -> None:
+        """ Starts the otbn.fi.char.bn.sel test.
+        """
+        # OtbnFi command.
+        self._ujson_otbn_fi_cmd()
+        # CharBnSel command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("CharBnSel").encode("ascii"))
+
+    def otbn_char_bn_rshi(self) -> None:
+        """ Starts the otbn.fi.char.bn.rshi test.
+        """
+        # OtbnFi command.
+        self._ujson_otbn_fi_cmd()
+        # CharBnRshi command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("CharBnRshi").encode("ascii"))
+
     def otbn_char_bn_wsrr(self) -> None:
         """ Starts the otbn.fi.char.bn.wsrr test.
         """
@@ -134,6 +161,15 @@ class OTFIOtbn:
         # LoadIntegrity command.
         time.sleep(0.01)
         self.target.write(json.dumps("LoadIntegrity").encode("ascii"))
+
+    def otbn_pc(self) -> None:
+        """ Starts the otbn.pc test.
+        """
+        # OtbnFi command.
+        self._ujson_otbn_fi_cmd()
+        # PC command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("PC").encode("ascii"))
 
     def init_keymgr(self, test: str) -> None:
         """ Initialize the key manager on the chip.


### PR DESCRIPTION
This PR consists of the following two commits:

- Extend the OTBN FI script such that inputs or initial configs can be transmitted
- Add new OTBN FI test command handlers