### PR TITLE
[chip] Add interface option

### DIFF
--- a/capture/capture_aes.py
+++ b/capture/capture_aes.py
@@ -102,7 +102,8 @@ def setup(cfg: dict, project: Path):
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
-        usb_serial = cfg["target"].get("usb_serial")
+        usb_serial = cfg["target"].get("usb_serial"),
+        interface = cfg["target"].get("interface")
     )
     target = Target(target_cfg)
 

--- a/capture/capture_hmac.py
+++ b/capture/capture_hmac.py
@@ -102,7 +102,8 @@ def setup(cfg: dict, project: Path):
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
-        usb_serial = cfg["target"].get("usb_serial")
+        usb_serial = cfg["target"].get("usb_serial"),
+        interface = cfg["target"].get("interface")
     )
     target = Target(target_cfg)
 

--- a/capture/capture_ibex.py
+++ b/capture/capture_ibex.py
@@ -90,7 +90,8 @@ def setup(cfg: dict, project: Path):
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
-        usb_serial = cfg["target"].get("usb_serial")
+        usb_serial = cfg["target"].get("usb_serial"),
+        interface = cfg["target"].get("interface")
     )
     target = Target(target_cfg)
 

--- a/capture/capture_kmac.py
+++ b/capture/capture_kmac.py
@@ -106,7 +106,8 @@ def setup(cfg: dict, project: Path):
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
-        usb_serial = cfg["target"].get("usb_serial")
+        usb_serial = cfg["target"].get("usb_serial"),
+        interface = cfg["target"].get("interface")
     )
     target = Target(target_cfg)
 

--- a/capture/capture_otbn.py
+++ b/capture/capture_otbn.py
@@ -116,7 +116,8 @@ def setup(cfg: dict, project: Path):
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
-        usb_serial = cfg["target"].get("usb_serial")
+        usb_serial = cfg["target"].get("usb_serial"),
+        interface = cfg["target"].get("interface")
     )
     target = Target(target_cfg)
 

--- a/capture/capture_sha3.py
+++ b/capture/capture_sha3.py
@@ -91,7 +91,8 @@ def setup(cfg: dict, project: Path):
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
-        usb_serial = cfg["target"].get("usb_serial")
+        usb_serial = cfg["target"].get("usb_serial"),
+        interface = cfg["target"].get("interface")
     )
     target = Target(target_cfg)
 

--- a/fault_injection/fi_crypto.py
+++ b/fault_injection/fi_crypto.py
@@ -48,7 +48,8 @@ def setup(cfg: dict, project: Path):
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
-        usb_serial = cfg["target"].get("usb_serial")
+        usb_serial = cfg["target"].get("usb_serial"),
+        interface = cfg["target"].get("interface")
     )
     target = Target(target_cfg)
 

--- a/fault_injection/fi_ibex.py
+++ b/fault_injection/fi_ibex.py
@@ -48,7 +48,8 @@ def setup(cfg: dict, project: Path):
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
-        usb_serial = cfg["target"].get("usb_serial")
+        usb_serial = cfg["target"].get("usb_serial"),
+        interface = cfg["target"].get("interface")
     )
     target = Target(target_cfg)
 

--- a/fault_injection/fi_otbn.py
+++ b/fault_injection/fi_otbn.py
@@ -48,7 +48,8 @@ def setup(cfg: dict, project: Path):
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
-        usb_serial = cfg["target"].get("usb_serial")
+        usb_serial = cfg["target"].get("usb_serial"),
+        interface = cfg["target"].get("interface")
     )
     target = Target(target_cfg)
 

--- a/fault_injection/fi_rng.py
+++ b/fault_injection/fi_rng.py
@@ -48,7 +48,8 @@ def setup(cfg: dict, project: Path):
         baudrate = cfg["target"].get("baudrate"),
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
-        usb_serial = cfg["target"].get("usb_serial")
+        usb_serial = cfg["target"].get("usb_serial"),
+        interface = cfg["target"].get("interface")
     )
     target = Target(target_cfg)
 

--- a/target/chip.py
+++ b/target/chip.py
@@ -13,11 +13,13 @@ class Chip():
     """
     def __init__(self, firmware, opentitantool_path,
                  boot_delay: Optional[int] = 1,
-                 usb_serial: Optional[str] = None):
+                 usb_serial: Optional[str] = None,
+                 interface: Optional[str] = "hyper310"):
         self.firmware = firmware
         self.opentitantool = opentitantool_path
         self.boot_delay = boot_delay
         self.usb_serial = usb_serial
+        self.interface = interface
         self._initialize_chip()
 
     def _initialize_chip(self):
@@ -27,14 +29,14 @@ class Chip():
             flash_process = Popen([self.opentitantool,
                                    "--usb-serial=" + str(self.usb_serial),
                                    "--rcfile=",
-                                   "--interface=hyper310",
+                                   "--interface=" + str(self.interface),
                                    "--exec", "transport init",
                                    "--exec", "bootstrap " + self.firmware, "no-op"],
                                   stdout=PIPE, stderr=PIPE)
         else:
             flash_process = Popen([self.opentitantool,
                                    "--rcfile=",
-                                   "--interface=hyper310",
+                                   "--interface=" + str(self.interface),
                                    "--exec", "transport init",
                                    "--exec", "bootstrap " + self.firmware, "no-op"],
                                   stdout=PIPE, stderr=PIPE)
@@ -52,14 +54,14 @@ class Chip():
         if self.usb_serial is not None and self.usb_serial != "":
             reset_process = Popen([self.opentitantool,
                                    "--usb-serial=" + str(self.usb_serial),
-                                   "--interface=hyper310",
+                                   "--interface=" + str(self.interface),
                                    "--exec", "transport init",
                                    "--exec", "gpio write RESET false",
                                    "--exec", "gpio write RESET true", "no-op"],
                                   stdout=PIPE, stderr=PIPE)
         else:
             reset_process = Popen([self.opentitantool,
-                                   "--interface=hyper310",
+                                   "--interface=" + str(self.interface),
                                    "--exec", "transport init",
                                    "--exec", "gpio write RESET false",
                                    "--exec", "gpio write RESET true", "no-op"],

--- a/target/targets.py
+++ b/target/targets.py
@@ -28,6 +28,7 @@ class TargetConfig:
     port: Optional[str] = None
     read_timeout: Optional[int] = 1
     usb_serial: Optional[str] = None
+    interface: Optional[str] = "hyper310"
 
 
 class Target:
@@ -60,7 +61,8 @@ class Target:
         elif self.target_cfg.target_type == "chip":
             target = Chip(firmware = self.target_cfg.fw_bin,
                           opentitantool_path = "../objs/opentitantool",
-                          usb_serial=self.target_cfg.usb_serial)
+                          usb_serial = self.target_cfg.usb_serial,
+                          interface = self.target_cfg.interface)
         else:
             raise RuntimeError("Error: Target not supported!")
         return target


### PR DESCRIPTION
The voyager board uses the "ftdi" interface while other boards use the "hyper310" interface. This commit makes the interface parameterisable. By setting
```
target:
  interface: "ftdi"
```
in the corresponding FI/SCA config, ot-sca can be used to analyze
the voyager board.