### PR TITLE
[ci] Fix CI runners

### DIFF
--- a/.github/workflows/lintpy.yml
+++ b/.github/workflows/lintpy.yml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "lint"
   lint:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "pytest"
   pytest:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Recently, the pytest and lintpy jobs were failing. The reason for this is that we are running these jobs on the latest Ubuntu version. However, we currently recommend using Ubuntu 22.04. Hence, lets pick this runner for the CI jobs.

Closes lowRISC/ot-sca#388