### PR TITLE
[cw] Add ID to CW Husky and CW310

### DIFF
--- a/capture/capture_aes.py
+++ b/capture/capture_aes.py
@@ -103,7 +103,8 @@ def setup(cfg: dict, project: Path):
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
         usb_serial = cfg["target"].get("usb_serial"),
-        interface = cfg["target"].get("interface")
+        interface = cfg["target"].get("interface"),
+        husky_serial = cfg["husky"].get("usb_serial")
     )
     target = Target(target_cfg)
 
@@ -138,6 +139,7 @@ def setup(cfg: dict, project: Path):
         sparsing = cfg[scope_type].get("sparsing"),
         scope_gain = cfg[scope_type].get("scope_gain"),
         pll_frequency = cfg["target"]["pll_frequency"],
+        scope_sn = cfg[scope_type].get("usb_serial"),
     )
     scope = Scope(scope_cfg)
 

--- a/capture/capture_hmac.py
+++ b/capture/capture_hmac.py
@@ -103,7 +103,8 @@ def setup(cfg: dict, project: Path):
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
         usb_serial = cfg["target"].get("usb_serial"),
-        interface = cfg["target"].get("interface")
+        interface = cfg["target"].get("interface"),
+        husky_serial = cfg["husky"].get("usb_serial")
     )
     target = Target(target_cfg)
 
@@ -138,6 +139,7 @@ def setup(cfg: dict, project: Path):
         sparsing = cfg[scope_type].get("sparsing"),
         scope_gain = cfg[scope_type].get("scope_gain"),
         pll_frequency = cfg["target"]["pll_frequency"],
+        scope_sn = cfg[scope_type].get("usb_serial"),
     )
     scope = Scope(scope_cfg)
 

--- a/capture/capture_ibex.py
+++ b/capture/capture_ibex.py
@@ -91,7 +91,8 @@ def setup(cfg: dict, project: Path):
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
         usb_serial = cfg["target"].get("usb_serial"),
-        interface = cfg["target"].get("interface")
+        interface = cfg["target"].get("interface"),
+        husky_serial = cfg["husky"].get("usb_serial")
     )
     target = Target(target_cfg)
 
@@ -126,6 +127,7 @@ def setup(cfg: dict, project: Path):
         sparsing = cfg[scope_type].get("sparsing"),
         scope_gain = cfg[scope_type].get("scope_gain"),
         pll_frequency = cfg["target"]["pll_frequency"],
+        scope_sn = cfg[scope_type].get("usb_serial"),
     )
     scope = Scope(scope_cfg)
 

--- a/capture/capture_kmac.py
+++ b/capture/capture_kmac.py
@@ -107,7 +107,8 @@ def setup(cfg: dict, project: Path):
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
         usb_serial = cfg["target"].get("usb_serial"),
-        interface = cfg["target"].get("interface")
+        interface = cfg["target"].get("interface"),
+        husky_serial = cfg["husky"].get("usb_serial")
     )
     target = Target(target_cfg)
 
@@ -142,6 +143,7 @@ def setup(cfg: dict, project: Path):
         sparsing = cfg[scope_type].get("sparsing"),
         scope_gain = cfg[scope_type].get("scope_gain"),
         pll_frequency = cfg["target"]["pll_frequency"],
+        scope_sn = cfg[scope_type].get("usb_serial"),
     )
     scope = Scope(scope_cfg)
 

--- a/capture/capture_otbn.py
+++ b/capture/capture_otbn.py
@@ -117,7 +117,8 @@ def setup(cfg: dict, project: Path):
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
         usb_serial = cfg["target"].get("usb_serial"),
-        interface = cfg["target"].get("interface")
+        interface = cfg["target"].get("interface"),
+        husky_serial = cfg["husky"].get("usb_serial")
     )
     target = Target(target_cfg)
 
@@ -152,6 +153,7 @@ def setup(cfg: dict, project: Path):
         sparsing=cfg[scope_type].get("sparsing"),
         scope_gain=cfg[scope_type].get("scope_gain"),
         pll_frequency=cfg["target"]["pll_frequency"],
+        scope_sn = cfg[scope_type].get("usb_serial"),
     )
     scope = Scope(scope_cfg)
 

--- a/capture/capture_sha3.py
+++ b/capture/capture_sha3.py
@@ -92,7 +92,8 @@ def setup(cfg: dict, project: Path):
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
         usb_serial = cfg["target"].get("usb_serial"),
-        interface = cfg["target"].get("interface")
+        interface = cfg["target"].get("interface"),
+        husky_serial = cfg["husky"].get("usb_serial")
     )
     target = Target(target_cfg)
 
@@ -127,6 +128,7 @@ def setup(cfg: dict, project: Path):
         sparsing = cfg[scope_type].get("sparsing"),
         scope_gain = cfg[scope_type].get("scope_gain"),
         pll_frequency = cfg["target"]["pll_frequency"],
+        scope_sn = cfg[scope_type].get("usb_serial"),
     )
     scope = Scope(scope_cfg)
 

--- a/capture/scopes/chipwhisperer/husky.py
+++ b/capture/scopes/chipwhisperer/husky.py
@@ -15,9 +15,10 @@ from util import check_version  # noqa: E402
 
 class Husky:
     def __init__(self, scope_gain, batch_mode, num_samples, num_segments,
-                 offset_samples, sampling_rate, pll_frequency):
-        check_version.check_husky("1.5.0")
+                 offset_samples, sampling_rate, pll_frequency, scope_sn):
+        check_version.check_husky("1.5.0", sn=scope_sn)
         self.scope = None
+        self.sn = scope_sn
         self.scope_gain = scope_gain
         self.batch_mode = batch_mode
         # In our setup, Husky operates on the PLL frequency of the target and
@@ -39,7 +40,7 @@ class Husky:
 
     def initialize_scope(self):
         """Initializes chipwhisperer scope."""
-        scope = cw.scope()
+        scope = cw.scope(sn=self.sn)
         scope.gain.db = self.scope_gain
         scope.adc.basic_mode = "rising_edge"
         if not scope._is_husky:

--- a/capture/scopes/scope.py
+++ b/capture/scopes/scope.py
@@ -28,6 +28,7 @@ class ScopeConfig:
     scope_gain: Optional[float] = 1
     pll_frequency: Optional[int] = 1
     sampling_rate: Optional[int] = 0
+    scope_sn: Optional[str] = None
 
 
 class Scope:
@@ -56,7 +57,8 @@ class Scope:
                           num_segments = self.scope_cfg.num_segments,
                           offset_samples = self.scope_cfg.offset_samples,
                           sampling_rate = self.scope_cfg.sampling_rate,
-                          pll_frequency = self.scope_cfg.pll_frequency
+                          pll_frequency = self.scope_cfg.pll_frequency,
+                          scope_sn = self.scope_cfg.scope_sn
                           )
             scope.initialize_scope()
             scope.configure_batch_mode()

--- a/fault_injection/fi_crypto.py
+++ b/fault_injection/fi_crypto.py
@@ -49,7 +49,8 @@ def setup(cfg: dict, project: Path):
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
         usb_serial = cfg["target"].get("usb_serial"),
-        interface = cfg["target"].get("interface")
+        interface = cfg["target"].get("interface"),
+        husky_serial = cfg["fisetup"].get("husky_serial")
     )
     target = Target(target_cfg)
 

--- a/fault_injection/fi_ibex.py
+++ b/fault_injection/fi_ibex.py
@@ -49,7 +49,8 @@ def setup(cfg: dict, project: Path):
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
         usb_serial = cfg["target"].get("usb_serial"),
-        interface = cfg["target"].get("interface")
+        interface = cfg["target"].get("interface"),
+        husky_serial = cfg["fisetup"].get("husky_serial")
     )
     target = Target(target_cfg)
 

--- a/fault_injection/fi_otbn.py
+++ b/fault_injection/fi_otbn.py
@@ -49,7 +49,8 @@ def setup(cfg: dict, project: Path):
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
         usb_serial = cfg["target"].get("usb_serial"),
-        interface = cfg["target"].get("interface")
+        interface = cfg["target"].get("interface"),
+        husky_serial = cfg["fisetup"].get("husky_serial")
     )
     target = Target(target_cfg)
 

--- a/fault_injection/fi_rng.py
+++ b/fault_injection/fi_rng.py
@@ -49,7 +49,8 @@ def setup(cfg: dict, project: Path):
         port = cfg["target"].get("port"),
         output_len = cfg["target"].get("output_len_bytes"),
         usb_serial = cfg["target"].get("usb_serial"),
-        interface = cfg["target"].get("interface")
+        interface = cfg["target"].get("interface"),
+        husky_serial = cfg["fisetup"].get("husky_serial")
     )
     target = Target(target_cfg)
 

--- a/target/targets.py
+++ b/target/targets.py
@@ -27,8 +27,9 @@ class TargetConfig:
     baudrate: Optional[int] = None
     port: Optional[str] = None
     read_timeout: Optional[int] = 1
-    usb_serial: Optional[str] = None
     interface: Optional[str] = "hyper310"
+    usb_serial: Optional[str] = None
+    husky_serial: Optional[str] = None
 
 
 class Target:
@@ -56,7 +57,9 @@ class Target:
                 pll_frequency = self.target_cfg.pll_frequency,
                 baudrate = self.target_cfg.baudrate,
                 output_len = self.target_cfg.output_len,
-                protocol = self.target_cfg.protocol
+                protocol = self.target_cfg.protocol,
+                usb_serial = self.target_cfg.usb_serial,
+                husky_serial = self.target_cfg.husky_serial
             )
         elif self.target_cfg.target_type == "chip":
             target = Chip(firmware = self.target_cfg.fw_bin,

--- a/util/spiflash.py
+++ b/util/spiflash.py
@@ -75,14 +75,15 @@ class SpiProgrammer:
     PAYLOAD_SIZE = 256
     MAX_BUSY_ITER_CNT = 500
 
-    def __init__(self, fpga):
+    def __init__(self, fpga, sn):
         """Inits a SpiProgrammer with a CW310/305.
 
         Args:
           fpga: CW310/305 to be programmed, ``chipwhisperer.capture.targets.CW310/305``.
+          sn: The USB serial number of the FPGA board.
         """
         self.pins = self.PIN_MAPPINGS[id(type(fpga))]
-        fpga.con()
+        fpga.con(sn=sn)
         self.io = fpga.gpio_mode()
         # Set strap pins as outputs
         for pin, mapped_to in self.pins._asdict().items():


### PR DESCRIPTION
Previously, attaching only one CW310 and Husky when not using a container was possible. With this commit, multiple boards and scopes can be connected when providing the ID of the Husky/CW FPGA board.