### PR TITLE
[capture] Add delay to AES FPGA capture

### DIFF
--- a/target/communication/sca_aes_commands.py
+++ b/target/communication/sca_aes_commands.py
@@ -174,6 +174,7 @@ class OTAES:
             self.target.wait_ack()
         else:
             # AesSca command.
+            time.sleep(0.02)
             self._ujson_aes_sca_cmd()
             # FvsrKeyBatchEncrypt command.
             self.target.write(json.dumps("FvsrKeyBatchEncrypt").encode("ascii"))


### PR DESCRIPTION
Unfortunately, the UART connection to the FPGA is quite iffy. It turns out that a small delay for the FvsrKeyBatchEncrypt cmd is needed. Otherwise, the command sometimes gets not received by the device. This happens with the latest CW310 firmware as well as UART control flow enabled in the SW.

This was detected now as on silicon this problem does not occur.