### PR TITLE
[fi] Add Sha256 command handlers

### DIFF
--- a/fault_injection/configs/pen.global_fi.crypto.sha256.cw310.yaml
+++ b/fault_injection/configs/pen.global_fi.crypto.sha256.cw310.yaml
@@ -1,0 +1,53 @@
+target:
+  target_type: cw310
+  fpga_bitstream: "../objs/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+  force_program_bitstream: False
+  fw_bin: "../objs/fi_ujson_fpga_cw310.bin"
+  output_len_bytes: 16
+  target_clk_mult: 0.24
+  target_freq: 24000000
+  baudrate: 115200
+  protocol: "ujson"
+  port: "/dev/ttyACM4"
+fisetup:
+  fi_gear: "husky"
+  fi_type: "voltage_glitch"
+  parameter_generation: "random"
+  # Voltage glitch width in cycles.
+  glitch_width_min: 5
+  glitch_width_max: 150
+  glitch_width_step: 3
+  # Range for trigger delay in cycles.
+  trigger_delay_min: 0
+  trigger_delay_max: 500
+  trigger_step: 10
+  # Number of iterations for the parameter sweep.
+  num_iterations: 100
+fiproject:
+  # Project database type and memory threshold.
+  project_db: "ot_fi_project"
+  project_mem_threshold: 10000
+  # Store FI plot.
+  show_plot: True
+  num_plots: 10
+  plot_x_axis: "trigger_delay"
+  plot_x_axis_legend: "[cycles]"
+  plot_y_axis: "glitch_width"
+  plot_y_axis_legend: "[cycles]"
+test:
+  which_test: "crypto_sha256_start"
+  # which_test: "crypto_sha256_msg"
+  # which_test: "crypto_sha256_process"
+  # which_test: "crypto_sha256_finish"
+  expected_result: '{"tag":[686569403,627255979,3962665531,1869430007,3580678696,2543765621,4151418325,927402239],"alerts":[0,0,0],"err_status":0}'
+  # Set to true if the test should ignore alerts returned by the test. As the
+  # alert handler on the device could sometime fire alerts that are not
+  # related to the FI, ignoring is by default set to true. A manual analysis
+  # still can be performed as the alerts are stored in the database.
+  ignore_alerts: True
+  # When True, the instruction cache is disabled. If False, use the default config
+  # (either on or off) set in the ROM.
+  icache_disable: False
+  # When True, the dummy instructions are disabled. If False, use the default config
+  # (either on or off) set in the ROM.
+  dummy_instr_disable: False

--- a/target/communication/fi_crypto_commands.py
+++ b/target/communication/fi_crypto_commands.py
@@ -162,6 +162,82 @@ class OTFICrypto:
                 "static_trigger": True, "squeeze_trigger": False}
         self.target.write(json.dumps(mode).encode("ascii"))
 
+    def crypto_sha256_start(self) -> None:
+        """ Starts the crypto.fi.sha256_start test with a hardcoded msg of 0.
+        """
+        # CryptoFi command.
+        self._ujson_crypto_cmd()
+        # Sha256 command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("Sha256").encode("ascii"))
+        # Data payload.
+        time.sleep(0.01)
+        data = {"message": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
+        self.target.write(json.dumps(data).encode("ascii"))
+        time.sleep(0.01)
+        # Trigger payload.
+        time.sleep(0.01)
+        mode = {"start_trigger": True, "msg_trigger": False, "process_trigger": False,
+                "finish_trigger": False}
+        self.target.write(json.dumps(mode).encode("ascii"))
+
+    def crypto_sha256_msg(self) -> None:
+        """ Starts the crypto.fi.sha256_msg test with a hardcoded msg of 0.
+        """
+        # CryptoFi command.
+        self._ujson_crypto_cmd()
+        # Sha256 command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("Sha256").encode("ascii"))
+        # Data payload.
+        time.sleep(0.01)
+        data = {"message": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
+        self.target.write(json.dumps(data).encode("ascii"))
+        time.sleep(0.01)
+        # Trigger payload.
+        time.sleep(0.01)
+        mode = {"start_trigger": False, "msg_trigger": True, "process_trigger": False,
+                "finish_trigger": False}
+        self.target.write(json.dumps(mode).encode("ascii"))
+
+    def crypto_sha256_process(self) -> None:
+        """ Starts the crypto.fi.sha256_process test with a hardcoded msg of 0.
+        """
+        # CryptoFi command.
+        self._ujson_crypto_cmd()
+        # Sha256 command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("Sha256").encode("ascii"))
+        # Data payload.
+        time.sleep(0.01)
+        data = {"message": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
+        self.target.write(json.dumps(data).encode("ascii"))
+        time.sleep(0.01)
+        # Trigger payload.
+        time.sleep(0.01)
+        mode = {"start_trigger": False, "msg_trigger": False, "process_trigger": True,
+                "finish_trigger": False}
+        self.target.write(json.dumps(mode).encode("ascii"))
+
+    def crypto_sha256_finish(self) -> None:
+        """ Starts the crypto.fi.sha256_finish test with a hardcoded msg of 0.
+        """
+        # CryptoFi command.
+        self._ujson_crypto_cmd()
+        # Sha256 command.
+        time.sleep(0.01)
+        self.target.write(json.dumps("Sha256").encode("ascii"))
+        # Data payload.
+        time.sleep(0.01)
+        data = {"message": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]}
+        self.target.write(json.dumps(data).encode("ascii"))
+        time.sleep(0.01)
+        # Trigger payload.
+        time.sleep(0.01)
+        mode = {"start_trigger": False, "msg_trigger": False, "process_trigger": False,
+                "finish_trigger": True}
+        self.target.write(json.dumps(mode).encode("ascii"))
+
     def start_test(self, cfg: dict) -> None:
         """ Start the selected test.
 


### PR DESCRIPTION
This commit adds the command handlers for the Sha256 FI tests to ot-sca.